### PR TITLE
feat: create an interface for the API Caller

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"io"
+    "net/http"
+
+    ghapi "github.com/cli/go-gh/v2/pkg/api"
+)
+
+type Caller interface {
+	Do(string, string, io.Reader, interface{}) error
+	Request(string, string, io.Reader) (*http.Response, error)
+}
+
+func NewGH() (Caller, error) {
+	return ghapi.DefaultRESTClient()
+}

--- a/internal/api/file/file.go
+++ b/internal/api/file/file.go
@@ -1,7 +1,7 @@
 package file
 
 import (
-	"bytes"
+	"bufio"
 	"errors"
 	"io"
 	"net/http"
@@ -31,12 +31,12 @@ func (a *API) Request(verb string, url string, _ io.Reader) (*http.Response, err
 }
 
 func (a *API) readFile() (*http.Response, error) {
-	content, err := os.ReadFile(a.path)
+	f, err := os.Open(a.path)
 	if err != nil {
 		return nil, err
 	}
 
 	return &http.Response{
-		Body: io.NopCloser(bytes.NewBuffer(content)),
+		Body: io.NopCloser(bufio.NewReader(f)),
 	}, nil
 }

--- a/internal/api/file/file.go
+++ b/internal/api/file/file.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/nobe4/gh-not/internal/gh"
 )
 
 type API struct {
@@ -17,11 +19,11 @@ func New(path string) *API {
 }
 
 func (a *API) Do(verb string, url string, _ io.Reader, _ interface{}) error {
-    return nil
+	return nil
 }
 
 func (a *API) Request(verb string, url string, _ io.Reader) (*http.Response, error) {
-	if verb == "GET" && url == "https://api.github.com/notifications" {
+	if verb == "GET" && url == gh.DefaultEndpoint {
 		return a.readFile()
 	}
 
@@ -30,11 +32,11 @@ func (a *API) Request(verb string, url string, _ io.Reader) (*http.Response, err
 
 func (a *API) readFile() (*http.Response, error) {
 	content, err := os.ReadFile(a.path)
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    return &http.Response{
-        Body: io.NopCloser(bytes.NewBuffer(content)),
-    }, nil
+	return &http.Response{
+		Body: io.NopCloser(bytes.NewBuffer(content)),
+	}, nil
 }

--- a/internal/api/file/file.go
+++ b/internal/api/file/file.go
@@ -1,0 +1,40 @@
+package file
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+)
+
+type API struct {
+	path string
+}
+
+func New(path string) *API {
+	return &API{path: path}
+}
+
+func (a *API) Do(verb string, url string, _ io.Reader, _ interface{}) error {
+    return nil
+}
+
+func (a *API) Request(verb string, url string, _ io.Reader) (*http.Response, error) {
+	if verb == "GET" && url == "https://api.github.com/notifications" {
+		return a.readFile()
+	}
+
+	return nil, errors.New("TODO")
+}
+
+func (a *API) readFile() (*http.Response, error) {
+	content, err := os.ReadFile(a.path)
+    if err != nil {
+        return nil, err
+    }
+
+    return &http.Response{
+        Body: io.NopCloser(bytes.NewBuffer(content)),
+    }, nil
+}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -10,7 +10,8 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/cli/go-gh/v2/pkg/api"
+	ghapi "github.com/cli/go-gh/v2/pkg/api"
+	"github.com/nobe4/gh-not/internal/api"
 	"github.com/nobe4/gh-not/internal/cache"
 	"github.com/nobe4/gh-not/internal/notifications"
 )
@@ -20,19 +21,14 @@ const (
 	retryCount      = 5
 )
 
-type APICaller interface {
-	Do(string, string, io.Reader, interface{}) error
-	Request(string, string, io.Reader) (*http.Response, error)
-}
-
 type Client struct {
-	API       APICaller
+	API       api.Caller
 	cache     cache.ExpiringReadWriter
 	refresh   bool
 	noRefresh bool
 }
 
-func NewClient(api APICaller, cache cache.ExpiringReadWriter, refresh, noRefresh bool) *Client {
+func NewClient(api api.Caller, cache cache.ExpiringReadWriter, refresh, noRefresh bool) *Client {
 	return &Client{
 		API:       api,
 		cache:     cache,
@@ -56,7 +52,7 @@ func (c *Client) loadCache() (notifications.Notifications, bool, error) {
 }
 
 func isRetryable(err error) bool {
-	var httpError *api.HTTPError
+	var httpError *ghapi.HTTPError
 
 	if errors.As(err, &httpError) {
 		switch httpError.StatusCode {

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultEndpoint = "https://api.github.com/notifications"
+	DefaultEndpoint = "https://api.github.com/notifications"
 	retryCount      = 5
 )
 
@@ -96,7 +96,7 @@ func (c *Client) paginateNotifications() ([]notifications.Notification, error) {
 		return ""
 	}
 
-	endpoint := defaultEndpoint
+	endpoint := DefaultEndpoint
 	for endpoint != "" {
 		slog.Info("API REST request", "endpoint", endpoint)
 


### PR DESCRIPTION
This provide an on-disk implementation of the API Caller depending on the use. Currently it helps to develop locally while keeping the API requests to a minimum. It's also useful when working offline.

Currently, only the basic "get me all notifications" request is handled, and further implementations will be done when necessary.