### PR TITLE
refactor(notifications): use pointers for Notifications

### DIFF
--- a/internal/actors/actors.go
+++ b/internal/actors/actors.go
@@ -25,5 +25,5 @@ func Map(client *gh.Client) ActorsMap {
 }
 
 type Actor interface {
-	Run(notifications.Notification) (notifications.Notification, string, error)
+	Run(*notifications.Notification) (string, error)
 }

--- a/internal/actors/debug/debug.go
+++ b/internal/actors/debug/debug.go
@@ -6,6 +6,6 @@ import (
 
 type Actor struct{}
 
-func (_ *Actor) Run(n notifications.Notification) (notifications.Notification, string, error) {
-	return n, "DEBUG" + n.ToString(), nil
+func (_ *Actor) Run(n *notifications.Notification) (string, error) {
+	return "DEBUG" + n.ToString(), nil
 }

--- a/internal/actors/done/done.go
+++ b/internal/actors/done/done.go
@@ -15,15 +15,16 @@ type Actor struct {
 	Client *gh.Client
 }
 
-func (a *Actor) Run(n notifications.Notification) (notifications.Notification, string, error) {
+func (a *Actor) Run(n *notifications.Notification) (string, error) {
 	slog.Debug("marking notification as done", "notification", n.ToString())
-
-	emptyNotification := notifications.Notification{}
 
 	err := a.Client.API.Do(http.MethodDelete, n.URL, nil, nil)
 	if err != nil {
-		return emptyNotification, "", err
+		return "", err
 	}
 
-	return emptyNotification, colors.Red("DONE ") + n.ToString(), nil
+	out := colors.Red("DONE ") + n.ToString()
+	n = nil
+
+	return out, nil
 }

--- a/internal/actors/hide/hide.go
+++ b/internal/actors/hide/hide.go
@@ -4,8 +4,8 @@ import "github.com/nobe4/gh-not/internal/notifications"
 
 type Actor struct{}
 
-func (_ *Actor) Run(n notifications.Notification) (notifications.Notification, string, error) {
+func (_ *Actor) Run(n *notifications.Notification) (string, error) {
 	n.Meta.Hidden = !n.Meta.Hidden
 
-	return n, "", nil
+	return "", nil
 }

--- a/internal/actors/pass/pass.go
+++ b/internal/actors/pass/pass.go
@@ -4,6 +4,6 @@ import "github.com/nobe4/gh-not/internal/notifications"
 
 type Actor struct{}
 
-func (_ *Actor) Run(n notifications.Notification) (notifications.Notification, string, error) {
-	return n, "", nil
+func (_ *Actor) Run(n *notifications.Notification) (string, error) {
+	return "", nil
 }

--- a/internal/actors/print/print.go
+++ b/internal/actors/print/print.go
@@ -6,10 +6,10 @@ import (
 
 type Actor struct{}
 
-func (_ *Actor) Run(n notifications.Notification) (notifications.Notification, string, error) {
+func (_ *Actor) Run(n *notifications.Notification) (string, error) {
 	if n.Meta.Hidden {
-		return n, "", nil
+		return "", nil
 	}
 
-	return n, n.ToString(), nil
+	return n.ToString(), nil
 }

--- a/internal/actors/read/read.go
+++ b/internal/actors/read/read.go
@@ -14,17 +14,17 @@ type Actor struct {
 	Client *gh.Client
 }
 
-func (a *Actor) Run(n notifications.Notification) (notifications.Notification, string, error) {
+func (a *Actor) Run(n *notifications.Notification) (string, error) {
 	err := a.Client.API.Do(http.MethodPatch, n.URL, nil, nil)
 
 	// go-gh currently fails to handle HTTP-205 correctly, however it's possible
 	// to catch this case.
 	// ref: https://github.com/cli/go-gh/issues/161
 	if err != nil && err.Error() != "unexpected end of JSON input" {
-		return n, "", err
+		return "", err
 	}
 
 	n.Unread = false
 
-	return n, colors.Yellow("READ") + n.ToString(), nil
+	return colors.Yellow("READ") + n.ToString(), nil
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"io"
-    "net/http"
+	"net/http"
 
-    ghapi "github.com/cli/go-gh/v2/pkg/api"
+	ghapi "github.com/cli/go-gh/v2/pkg/api"
 )
 
 type Caller interface {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -75,7 +75,7 @@ func setupGlobals(cmd *cobra.Command, args []string) error {
 	var apiCaller api.Caller
 
 	if notificationDumpPath != "" {
-        apiCaller = file.New(notificationDumpPath)
+		apiCaller = file.New(notificationDumpPath)
 	} else {
 		apiCaller, err = api.NewGH()
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,7 @@ func (c *Config) Apply(n notifications.Notifications, actors map[string]actors.A
 				if noop {
 					fmt.Printf("NOOP'ing action %s on notification %s\n", rule.Action, notification.ToString())
 				} else {
-					notification, out, err = actor.Run(notification)
+					out, err = actor.Run(notification)
 					if err != nil {
 						slog.Error("action failed", "action", rule.Action, "err", err)
 					}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ func (c *Config) Apply(n notifications.Notifications, actors map[string]actors.A
 				slog.Error("unknown action", "action", rule.Action)
 			}
 
-            // FIXME: is this still needed?
+			// FIXME: is this still needed?
 			n[i] = notification
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,7 @@ func (c *Config) Apply(n notifications.Notifications, actors map[string]actors.A
 				slog.Error("unknown action", "action", rule.Action)
 			}
 
+            // FIXME: is this still needed?
 			n[i] = notification
 		}
 	}

--- a/internal/gh/enrichments.go
+++ b/internal/gh/enrichments.go
@@ -7,13 +7,13 @@ import (
 	"github.com/nobe4/gh-not/internal/notifications"
 )
 
-func (c *Client) enrichNotification(n notifications.Notification) (notifications.Notification, error) {
+func (c *Client) enrichNotification(n *notifications.Notification) error {
 	extra := struct {
 		User  notifications.User `json:"user"`
 		State string             `json:"state"`
 	}{}
 	if err := c.API.Do(http.MethodGet, n.Subject.URL, nil, &extra); err != nil {
-		return n, err
+		return err
 	}
 
 	slog.Debug("adding author to notification", "notifications", n)
@@ -22,5 +22,5 @@ func (c *Client) enrichNotification(n notifications.Notification) (notifications
 	slog.Debug("adding state to notification's suject", "notifications", n)
 	n.Subject.State = extra.State
 
-	return n, nil
+	return nil
 }

--- a/internal/jq/jq.go
+++ b/internal/jq/jq.go
@@ -7,6 +7,8 @@ import (
 	"github.com/nobe4/gh-not/internal/notifications"
 )
 
+// TODO: refactor this as a callback to be called on n.Filter(flt) and have
+// n.Filter call .Compact
 // Filter applies a `.[] | select(filter)` on the notifications.
 func Filter(filter string, n notifications.Notifications) (notifications.Notifications, error) {
 	if filter == "" {

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nobe4/gh-not/internal/colors"
 )
 
-type Notifications []Notification
+type Notifications []*Notification
 
 type Notification struct {
 	// Standard API fields
@@ -138,15 +138,16 @@ func (n Notifications) IDList() []string {
 	return ids
 }
 
+// TODO: rename to `Compact`
 func (n Notifications) DeleteNil() Notifications {
-	return slices.DeleteFunc(n, func(n Notification) bool {
+	return slices.DeleteFunc(n, func(n *Notification) bool {
 		return n.Id == ""
 	})
 }
 
 func (n Notifications) Uniq() Notifications {
 	seenIds := map[string]bool{}
-	return slices.DeleteFunc(n, func(n Notification) bool {
+	return slices.DeleteFunc(n, func(n *Notification) bool {
 		if _, ok := seenIds[n.Id]; ok {
 			return true
 		}

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -141,7 +141,7 @@ func (n Notifications) IDList() []string {
 // TODO: rename to `Compact`
 func (n Notifications) DeleteNil() Notifications {
 	return slices.DeleteFunc(n, func(n *Notification) bool {
-		return n.Id == ""
+		return n == nil
 	})
 }
 

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -13,7 +13,7 @@ func TestIDList(t *testing.T) {
 
 	for i, id := range ids {
 		if id != got[i] {
-			t.Fatalf("expected %+v but got %+v", id, got[i])
+			t.Fatalf("expected %d: %s but got %s", i, id, got[i])
 		}
 	}
 }
@@ -35,5 +35,30 @@ func TestDeleteNil(t *testing.T) {
 
 	if got[1] != n1 {
 		t.Fatalf("expected %+v but got %+v", n1, got[1])
+	}
+}
+
+func TestUniq(t *testing.T) {
+	n0 := &Notification{Id: "0"}
+	n1 := &Notification{Id: "1"}
+	n2 := &Notification{Id: "2"}
+	n := Notifications{n0, n1, n2, n0, n1, n2}
+
+	got := n.Uniq()
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 elements but got %d\n%+v", len(got), got)
+	}
+
+	if got[0] != n0 {
+		t.Fatalf("expected %+v but got %+v", n0, got[0])
+	}
+
+	if got[1] != n1 {
+		t.Fatalf("expected %+v but got %+v", n1, got[1])
+	}
+
+	if got[2] != n2 {
+		t.Fatalf("expected %+v but got %+v", n2, got[2])
 	}
 }

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -2,6 +2,22 @@ package notifications
 
 import "testing"
 
+func TestIDList(t *testing.T) {
+	n := Notifications{}
+	ids := []string{"0", "1", "2"}
+	for _, id := range ids {
+		n = append(n, &Notification{Id: id})
+	}
+
+	got := n.IDList()
+
+	for i, id := range ids {
+		if id != got[i] {
+			t.Fatalf("expected %+v but got %+v", id, got[i])
+		}
+	}
+}
+
 func TestDeleteNil(t *testing.T) {
 	n0 := &Notification{Id: "0"}
 	n1 := &Notification{Id: "1"}
@@ -13,11 +29,11 @@ func TestDeleteNil(t *testing.T) {
 		t.Fatalf("expected 2 elements but got %d\n%+v", len(got), got)
 	}
 
-    if got[0] != n0 {
+	if got[0] != n0 {
 		t.Fatalf("expected %+v but got %+v", n0, got[0])
-    }
+	}
 
-    if got[1] != n1 {
+	if got[1] != n1 {
 		t.Fatalf("expected %+v but got %+v", n1, got[1])
-    }
+	}
 }

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -62,3 +62,24 @@ func TestUniq(t *testing.T) {
 		t.Fatalf("expected %+v but got %+v", n2, got[2])
 	}
 }
+
+func TestFilterFromIds(t *testing.T) {
+	n0 := &Notification{Id: "0"}
+	n1 := &Notification{Id: "1"}
+	n2 := &Notification{Id: "2"}
+	n := Notifications{n0, n1, n2}
+
+	got := n.FilterFromIds([]string{"0", "2"})
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 elements but got %d\n%+v", len(got), got)
+	}
+
+	if got[0] != n0 {
+		t.Fatalf("expected %+v but got %+v", n0, got[0])
+	}
+
+	if got[1] != n2 {
+		t.Fatalf("expected %+v but got %+v", n2, got[1])
+	}
+}

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -1,0 +1,23 @@
+package notifications
+
+import "testing"
+
+func TestDeleteNil(t *testing.T) {
+	n0 := &Notification{Id: "0"}
+	n1 := &Notification{Id: "1"}
+	n := Notifications{nil, nil, n0, nil, n1, nil}
+
+	got := n.DeleteNil()
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 elements but got %d\n%+v", len(got), got)
+	}
+
+    if got[0] != n0 {
+		t.Fatalf("expected %+v but got %+v", n0, got[0])
+    }
+
+    if got[1] != n1 {
+		t.Fatalf("expected %+v but got %+v", n1, got[1])
+    }
+}

--- a/internal/views/command/command.go
+++ b/internal/views/command/command.go
@@ -20,10 +20,10 @@ type Model struct {
 	keys                  keymap
 	input                 textinput.Model
 	actors                actors.ActorsMap
-	selectedNotifications func(func(notifications.Notification))
+	selectedNotifications func(func(*notifications.Notification))
 }
 
-func New(actors actors.ActorsMap, selectedNotifications func(func(notifications.Notification))) Model {
+func New(actors actors.ActorsMap, selectedNotifications func(func(*notifications.Notification))) Model {
 	model := Model{
 		keys: keymap{
 			quit: key.NewBinding(
@@ -102,9 +102,9 @@ func (m Model) runCommand(command string) tea.Cmd {
 
 		hasSelected := false
 
-		m.selectedNotifications(func(n notifications.Notification) {
+		m.selectedNotifications(func(n *notifications.Notification) {
 			hasSelected = true
-			n, outn, err := actor.Run(n)
+			outn, err := actor.Run(n)
 			if err != nil {
 				result.Err = err
 			} else {

--- a/internal/views/normal/normal.go
+++ b/internal/views/normal/normal.go
@@ -236,7 +236,7 @@ func (m Model) View() string {
 	return out
 }
 
-func (m Model) SelectedNotificationsFunc(cb func(notifications.Notification)) {
+func (m Model) SelectedNotificationsFunc(cb func(*notifications.Notification)) {
 	for i, selected := range m.selected {
 		if selected {
 			cb(m.choices[i])


### PR DESCRIPTION
This enables in-place edit of the notifications in the list and will enable later easier management with a single Notifications instance.

It also replaces the remaining instances of `[]Notification` with `Notifications`.