### PR TITLE
refactor(notifications): rename ToDelete to Done

### DIFF
--- a/internal/actors/done/done.go
+++ b/internal/actors/done/done.go
@@ -20,7 +20,7 @@ type Actor struct {
 func (a *Actor) Run(n *notifications.Notification, w io.Writer) error {
 	slog.Debug("marking notification as done", "notification", n.Debug())
 
-	n.Meta.ToDelete = true
+	n.Meta.Done = true
 
 	err := a.Client.API.Do(http.MethodDelete, n.URL, nil, nil)
 	if err != nil {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	notifications := manager.Notifications
+	notifications := manager.Notifications.Visible()
 
 	if filterFlag != "" {
 		notificationsList, err := jq.Filter(filterFlag, notifications)

--- a/internal/cmd/repl.go
+++ b/internal/cmd/repl.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func runRepl(cmd *cobra.Command, args []string) error {
-	notifications := manager.Notifications
+	notifications := manager.Notifications.Visible()
 
 	renderCache, err := notifications.Table()
 	if err != nil {

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -29,14 +29,18 @@ type Notification struct {
 	Author User `json:"author"`
 
 	// gh-not specific fields
+	// Those fields are not part of the GitHub API and will persist between
+	// syncs.
 	Meta Meta `json:"meta"`
 }
 
 type Meta struct {
+	// Hide the notification from the user
 	Hidden bool `json:"hidden"`
 
-	// TODO: Rename to `Done`
-	ToDelete bool `json:"to_delete"`
+	// Mark the notification as done, will be deleted as soon as it's missing
+	// from the remote notification list.
+	Done bool `json:"done"`
 }
 
 type Subject struct {
@@ -91,7 +95,7 @@ func (n Notifications) IDList() []string {
 // TODO: in-place update
 func (n Notifications) Compact() Notifications {
 	return slices.DeleteFunc(n, func(n *Notification) bool {
-		return n == nil || n.Meta.ToDelete
+		return n == nil
 	})
 }
 

--- a/internal/notifications/sync_test.go
+++ b/internal/notifications/sync_test.go
@@ -7,7 +7,7 @@ func TestSync(t *testing.T) {
 	n0Hidden := &Notification{Id: "0", Meta: Meta{Hidden: true}}
 	n0Updated := &Notification{Id: "0"}
 	n1 := &Notification{Id: "1"}
-	n1ToDelete := &Notification{Id: "1", Meta: Meta{ToDelete: true}}
+	n1Done := &Notification{Id: "1", Meta: Meta{Done: true}}
 
 	tests := []struct {
 		name     string
@@ -46,7 +46,7 @@ func TestSync(t *testing.T) {
 		// (4)Drop
 		{
 			name:     "cleanup notifications",
-			local:    Notifications{n0Hidden, n1ToDelete},
+			local:    Notifications{n0Hidden, n1Done},
 			expected: Notifications{n0Hidden},
 		},
 
@@ -55,9 +55,9 @@ func TestSync(t *testing.T) {
 		// (2)Update
 		{
 			name:     "hidden notification present in remote",
-			local:    Notifications{n0Hidden, n1ToDelete},
+			local:    Notifications{n0Hidden, n1Done},
 			remote:   Notifications{n0, n1},
-			expected: Notifications{n0Hidden, n1ToDelete},
+			expected: Notifications{n0Hidden, n1Done},
 		},
 		{
 			name:     "updated notification present in remote",

--- a/internal/notifications/view.go
+++ b/internal/notifications/view.go
@@ -66,6 +66,20 @@ func (n Notifications) String() string {
 	return out
 }
 
+func (n Notifications) Visible() Notifications {
+	visible := Notifications{}
+	for _, n := range n {
+		if n.Visible() {
+			visible = append(visible, n)
+		}
+	}
+	return visible
+}
+
+func (n Notification) Visible() bool {
+	return !n.Meta.Done && !n.Meta.Hidden
+}
+
 func (n Notifications) Table() (string, error) {
 	out := bytes.Buffer{}
 

--- a/internal/notifications/view_test.go
+++ b/internal/notifications/view_test.go
@@ -1,0 +1,22 @@
+package notifications
+
+import "testing"
+
+func TestVisible(t *testing.T) {
+	n := Notifications{
+		&Notification{Meta: Meta{Done: false, Hidden: false}},
+		&Notification{Meta: Meta{Done: true, Hidden: false}},
+		&Notification{Meta: Meta{Done: false, Hidden: true}},
+		&Notification{Meta: Meta{Done: true, Hidden: true}},
+	}
+
+	visible := n.Visible()
+
+	if len(visible) != 1 {
+		t.Errorf("Expected 1, got %d", len(visible))
+	}
+
+	if visible[0] != n[0] {
+		t.Errorf("Expected %v, got %v", n[0], visible[0])
+	}
+}


### PR DESCRIPTION
clarify the naming and align the name with the `done` action


BREAKING CHANGE: `Meta.ToDelete` is now `Meta.Done`