### PR TITLE
fix(views): add conditional preventing failure on missing config

### DIFF
--- a/internal/views/command/command.go
+++ b/internal/views/command/command.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -41,7 +42,13 @@ func New(actors actors.ActorsMap, selectedNotifications func(func(*notifications
 		suggestions = append(suggestions, k)
 	}
 
-	model.input.Prompt = keymap["normal"]["command mode"][0]
+	if keymap["normal"] != nil && keymap["normal"]["command mode"] != nil {
+		model.input.Prompt = keymap["normal"]["command mode"][0]
+	} else {
+		slog.Warn("No prompt for command mode, using default ':'. Make sure the config sets keymap.normal.'command mode'.")
+		model.input.Prompt = ":"
+	}
+
 	model.input.SetSuggestions(suggestions)
 	model.input.ShowSuggestions = true
 

--- a/internal/views/filter/filter.go
+++ b/internal/views/filter/filter.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -43,7 +44,13 @@ func New(visibleLines func(func(string, int)), keymap config.Keymap) Model {
 		visibleLines: visibleLines,
 	}
 
-	model.input.Prompt = keymap["normal"]["filter mode"][0]
+	if keymap["normal"] != nil && keymap["normal"]["filter mode"] != nil {
+		model.input.Prompt = keymap["normal"]["filter mode"][0]
+	} else {
+		slog.Warn("No prompt for filter mode, using default '/'. Make sure the config sets keymap.normal.'filter mode'.")
+		model.input.Prompt = "/"
+	}
+
 	model.input.Placeholder = "filter"
 
 	return model


### PR DESCRIPTION
This will ensure that even if the configuration is missing a 'command mode' or 'filter mode' key, the program will not fail. This is a temporary fix before #59 gets implemented.