### PR TITLE
fix(actors): add space after the actor's verb

### DIFF
--- a/internal/actors/debug/debug.go
+++ b/internal/actors/debug/debug.go
@@ -11,7 +11,7 @@ import (
 type Actor struct{}
 
 func (_ *Actor) Run(n *notifications.Notification, w io.Writer) error {
-	fmt.Fprint(w, colors.Yellow("DEBUG"+n.String()))
+	fmt.Fprint(w, colors.Yellow("DEBUG ")+n.String())
 
 	return nil
 }

--- a/internal/actors/done/done.go
+++ b/internal/actors/done/done.go
@@ -27,7 +27,7 @@ func (a *Actor) Run(n *notifications.Notification, w io.Writer) error {
 		return err
 	}
 
-	fmt.Fprint(w, colors.Red("DONE")+n.String())
+	fmt.Fprint(w, colors.Red("DONE ")+n.String())
 
 	return nil
 }

--- a/internal/actors/read/read.go
+++ b/internal/actors/read/read.go
@@ -28,7 +28,7 @@ func (a *Actor) Run(n *notifications.Notification, w io.Writer) error {
 
 	n.Unread = false
 
-	fmt.Fprint(w, colors.Yellow("READ")+n.String())
+	fmt.Fprint(w, colors.Yellow("READ ")+n.String())
 
 	return nil
 }


### PR DESCRIPTION
This improves the readability of the output.