### PR TITLE
fix(cmd): run manager.save only on commands that load and change it

### DIFF
--- a/internal/cmd/repl.go
+++ b/internal/cmd/repl.go
@@ -41,5 +41,10 @@ func runRepl(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := manager.Save(); err != nil {
+		slog.Error("Failed to save the notifications", "err", err)
+		return err
+	}
+
 	return nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -37,9 +37,8 @@ var (
   gh-not --from-file notifications.json list
   gh-not sync --refresh --verbosity 4
 `,
-		PersistentPreRunE:  setupGlobals,
-		PersistentPostRunE: postRunE,
-		SilenceErrors:      true,
+		PersistentPreRunE: setupGlobals,
+		SilenceErrors:     true,
 	}
 )
 
@@ -86,15 +85,6 @@ func setupGlobals(cmd *cobra.Command, args []string) error {
 	}
 
 	manager = managerPkg.New(config.Data, caller, refreshFlag, noRefreshFlag)
-
-	return nil
-}
-
-func postRunE(_ *cobra.Command, _ []string) error {
-	if err := manager.Save(); err != nil {
-		slog.Error("Failed to save the notifications", "err", err)
-		return err
-	}
 
 	return nil
 }

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -39,5 +39,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := manager.Save(); err != nil {
+		slog.Error("Failed to save the notifications", "err", err)
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
Only `sync` and `repl` modify the notification list, so only those commands need to save the cache after.

Fix #89 