### PR TITLE
feat(config, jq): add rule testing during config parsing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,12 @@ func New(path string) (*Config, error) {
 		return nil, err
 	}
 
+	for _, rule := range c.Data.Rules {
+		if err := rule.Test(); err != nil {
+			return nil, err
+		}
+	}
+
 	return c, nil
 }
 

--- a/internal/config/rule.go
+++ b/internal/config/rule.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"log/slog"
+
 	"github.com/nobe4/gh-not/internal/jq"
 	"github.com/nobe4/gh-not/internal/notifications"
 )
@@ -36,6 +38,18 @@ type Rule struct {
 	// Action is the action to take on the filtered notifications.
 	// See github.com/nobe4/internal/actors for list of available actions.
 	Action string `mapstructure:"action"`
+}
+
+// Test tests the rule for correctness.
+func (r Rule) Test() error {
+	for _, filter := range r.Filters {
+		if err := jq.Validate(filter); err != nil {
+			slog.Error("rule failed", "rule", r.Name, "filter", filter, "err", err)
+			return err
+		}
+	}
+
+	return nil
 }
 
 // FilterIds filters the notifications with the jq filters and returns the IDs.

--- a/internal/jq/jq.go
+++ b/internal/jq/jq.go
@@ -55,3 +55,8 @@ func Filter(filter string, n notifications.Notifications) (notifications.Notific
 
 	return n.FilterFromIds(filteredIDs), nil
 }
+
+func Validate(filter string) error {
+	_, err := gojq.Parse(filter)
+	return err
+}

--- a/internal/jq/jq_test.go
+++ b/internal/jq/jq_test.go
@@ -99,3 +99,43 @@ func TestFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    string
+		assertErr func(t *testing.T, err error)
+	}{
+		{
+			name:   "empty filter",
+			filter: "",
+		},
+		{
+			name:   "invalid filter",
+			filter: "!!!",
+			assertErr: func(t *testing.T, err error) {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+
+				expected := &gojq.ParseError{}
+				if !errors.As(err, &expected) {
+					t.Fatalf("expected error of type %T but got %T", expected, err)
+				}
+			},
+		},
+		{
+			name:   "valid filter",
+			filter: ".id == 1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Validate(test.filter)
+			if test.assertErr != nil {
+				test.assertErr(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This caches during the config parsing any invalid JQ filter. 
cc #86

Thanks @grantbirki for the help debugging this.