### PR TITLE
feat(build): simplify build/install process by pulling debug info

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,10 +12,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - >
-        -s -w -X github.com/nobe4/gh-not/internal/cmd.version={{.Version}}
-              -X github.com/nobe4/gh-not/internal/cmd.commit={{.Commit}}
-              -X github.com/nobe4/gh-not/internal/cmd.date={{.Date}}
+      - -s -w -X github.com/nobe4/gh-not/internal/version.tag={{.Tag}}
 
 archives:
   - name_template: "{{ .Os }}-{{ .Arch }}"

--- a/README.md
+++ b/README.md
@@ -17,15 +17,18 @@
     Is used with `gh not`, while the others `gh-not`. The documentation uses
     `gh-not` exclusively.
 
-- Install via `go`:
+- Install via `go install`:
     ```shell
-    go install github.com/nobe4/gh-not/cmd/gh-not@latest
+    go install \
+        --ldflags="-s -w -X github.com/nobe4/gh-not/internal/version.tag=$(git tag --points-at HEAD)" \
+        github.com/nobe4/gh-not/cmd/gh-not@latest
     ```
 
 - Build from sources
-
     ```shell
-    go build ./cmd/gh-not
+    go build \
+        --ldflags="-s -w -X github.com/nobe4/gh-not/internal/version.tag=$(git tag --points-at HEAD)" \
+        ./cmd/gh-not
     ```
 
 # Getting started

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,8 +24,9 @@ var (
 	manager *managerPkg.Manager
 
 	rootCmd = &cobra.Command{
-		Use:   "gh-not",
-		Short: "Manage your GitHub notifications",
+		Use:     "gh-not",
+		Short:   "Manage your GitHub notifications",
+		Version: version.String(),
 		Example: `
   gh-not --config list
   gh-not --no-refresh list
@@ -42,8 +43,6 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.Version = version.String()
-
 	rootCmd.Root().CompletionOptions.DisableDefaultCmd = true
 
 	rootCmd.PersistentFlags().IntVarP(&verbosityFlag, "verbosity", "v", 1, "Change logger verbosity")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/nobe4/gh-not/internal/api"
@@ -10,14 +9,11 @@ import (
 	configPkg "github.com/nobe4/gh-not/internal/config"
 	"github.com/nobe4/gh-not/internal/logger"
 	managerPkg "github.com/nobe4/gh-not/internal/manager"
+	"github.com/nobe4/gh-not/internal/version"
 	"github.com/spf13/cobra"
 )
 
 var (
-	version = "dev"
-	commit  = "123abc"
-	date    = "now"
-
 	verbosityFlag        int
 	configPathFlag       string
 	notificationDumpPath string
@@ -28,9 +24,8 @@ var (
 	manager *managerPkg.Manager
 
 	rootCmd = &cobra.Command{
-		Use:     "gh-not",
-		Version: fmt.Sprintf("v%s (%s) built at %s\nhttps://github.com/nobe4/gh-not/releases/tag/v%s", version, commit, date, version),
-		Short:   "Manage your GitHub notifications",
+		Use:   "gh-not",
+		Short: "Manage your GitHub notifications",
 		Example: `
   gh-not --config list
   gh-not --no-refresh list
@@ -47,6 +42,8 @@ func Execute() error {
 }
 
 func init() {
+	rootCmd.Version = version.String()
+
 	rootCmd.Root().CompletionOptions.DisableDefaultCmd = true
 
 	rootCmd.PersistentFlags().IntVarP(&verbosityFlag, "verbosity", "v", 1, "Change logger verbosity")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,27 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+var tag = "dev" // set via ldflags
+var commit = "123abc"
+var date = "now"
+
+func String() string {
+	info, ok := debug.ReadBuildInfo()
+
+	if ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commit = setting.Value
+			}
+			if setting.Key == "vcs.time" {
+				date = setting.Value
+			}
+		}
+	}
+
+	return fmt.Sprintf("%s (%s) built at %s\nhttps://github.com/nobe4/gh-not/releases/tag/%s", tag, commit, date, tag)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,9 +5,13 @@ import (
 	"runtime/debug"
 )
 
-var tag = "dev" // set via ldflags
-var commit = "123abc"
-var date = "now"
+var (
+	tag    = "dev" // set via ldflags
+	commit = "123abc"
+	date   = "now"
+)
+
+const template = "%s (%s) built at %s\nhttps://github.com/nobe4/gh-not/releases/tag/%s"
 
 func String() string {
 	info, ok := debug.ReadBuildInfo()
@@ -23,5 +27,5 @@ func String() string {
 		}
 	}
 
-	return fmt.Sprintf("%s (%s) built at %s\nhttps://github.com/nobe4/gh-not/releases/tag/%s", tag, commit, date, tag)
+	return fmt.Sprintf(template, tag, commit, date, tag)
 }


### PR DESCRIPTION
Starting in 1.18, git information is stored in the binary, it's possible to pull it at runtime. Using the runtime/debug package, we can extract the `commit` and `date` information.

The `version` (renamed `tag`) still comes from the ldflags. This allows for simpler build/install process.

- https://pkg.go.dev/runtime/debug@go1.22.5#ReadBuildInfo
- https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/

Thanks @natefinch, @chrisgavin, @cogswell for the help.

Fix #95