### PR TITLE
fix: only enrich non-done notifications

### DIFF
--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -144,19 +144,18 @@ func (c *Client) paginate() (notifications.Notifications, error) {
 	return list, nil
 }
 
-func (c *Client) Notifications() (notifications.Notifications, error) {
-	list, err := c.paginate()
-	if err != nil {
-		return nil, err
-	}
-
-	for i, n := range list {
+func (c *Client) Enrich(ns notifications.Notifications) (notifications.Notifications, error) {
+	for i, n := range ns {
 		if err := c.enrichNotification(n); err != nil {
 			return nil, err
 		}
 
-		list[i] = n
+		ns[i] = n
 	}
 
-	return list, nil
+	return ns, nil
+}
+
+func (c *Client) Notifications() (notifications.Notifications, error) {
+	return c.paginate()
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -79,7 +79,9 @@ func (m *Manager) Load() error {
 
 	m.Notifications = allNotifications.Uniq()
 
-	return nil
+	m.Notifications, err = m.client.Enrich(m.Notifications)
+
+	return err
 }
 
 func (m *Manager) shouldRefresh(expired bool) bool {
@@ -131,6 +133,7 @@ func (m *Manager) Apply(noop bool) error {
 		slog.Debug("apply rule", "name", rule.Name, "count", len(selectedIds))
 
 		for _, notification := range m.Notifications.FilterFromIds(selectedIds) {
+			// TODO: add --force flag to ignore this
 			if notification.Meta.Done {
 				continue
 			}


### PR DESCRIPTION
The logic to ignore done notifications was moot given that it ran on notifications not yet sync'ed. This meant the `Meta.Done` field was _always_ set to `false`.

This change moves the enrichment after the sync between the API and cached notifications, at which point the `Meta` will exist.

Fix https://github.com/nobe4/gh-not/issues/98