### PR TITLE
feat(hide): rework hidden state

### DIFF
--- a/internal/actors/hide/hide.go
+++ b/internal/actors/hide/hide.go
@@ -1,22 +1,22 @@
 package hide
 
 import (
+	"fmt"
 	"io"
+	"log/slog"
 
+	"github.com/nobe4/gh-not/internal/colors"
 	"github.com/nobe4/gh-not/internal/notifications"
 )
 
 type Actor struct{}
 
-func (_ *Actor) Run(n *notifications.Notification, _ io.Writer) error {
-	n.Meta.Hidden = !n.Meta.Hidden
+func (_ *Actor) Run(n *notifications.Notification, w io.Writer) error {
+	slog.Debug("marking notification as hidden", "notification", n.Id)
 
-	n = &notifications.Notification{
-		Id: n.Id,
-		Meta: notifications.Meta{
-			Hidden: n.Meta.Hidden,
-		},
-	}
+	n.Meta.Hidden = true
+
+	fmt.Fprint(w, colors.Red("HIDE ")+n.String())
 
 	return nil
 }

--- a/internal/actors/hide/hide.go
+++ b/internal/actors/hide/hide.go
@@ -11,5 +11,12 @@ type Actor struct{}
 func (_ *Actor) Run(n *notifications.Notification, _ io.Writer) error {
 	n.Meta.Hidden = !n.Meta.Hidden
 
+	n = &notifications.Notification{
+		Id: n.Id,
+		Meta: notifications.Meta{
+			Hidden: n.Meta.Hidden,
+		},
+	}
+
 	return nil
 }

--- a/internal/notifications/sync.go
+++ b/internal/notifications/sync.go
@@ -10,7 +10,7 @@ It applies the following rules:
 	| remote \ local | Missing    | Exist      | Done       | Hidden   |
 	| ---            | ---        | ---        | ---        | ---      |
 	| Exist          | (1) Insert | (2) Update | (2) Update | (3) Keep |
-	| Missing        | (3) Keep   | (3) Keep   | (4) Drop   | (4) Drop |
+	| Missing        |            | (3) Keep   | (4) Drop   | (4) Drop |
 
 	(1) Insert: Add the notification ass is.
 	(2) Update: Update the local notification with the remote data, keep the Meta

--- a/internal/notifications/sync_test.go
+++ b/internal/notifications/sync_test.go
@@ -65,7 +65,7 @@ func TestSync(t *testing.T) {
 		{
 			name:     "hidden notification present in remote",
 			local:    Notifications{n0Hidden, n1Done},
-			remote:   Notifications{n0, n1},
+			remote:   Notifications{n0Updated, n1},
 			expected: Notifications{n0Hidden, n1Done},
 		},
 		{

--- a/internal/notifications/sync_test.go
+++ b/internal/notifications/sync_test.go
@@ -18,7 +18,7 @@ func TestSync(t *testing.T) {
 		remote   Notifications
 		expected Notifications
 	}{
-		// (1)Insert
+		// (1) Insert
 		{
 			name:     "one new notification",
 			remote:   Notifications{n0},
@@ -30,7 +30,7 @@ func TestSync(t *testing.T) {
 			expected: Notifications{n0, n1},
 		},
 
-		// (3)Noop
+		// (3) Keep
 		{
 			name: "no notifications",
 		},
@@ -45,17 +45,23 @@ func TestSync(t *testing.T) {
 			remote:   Notifications{n1},
 			expected: Notifications{n0, n1},
 		},
-
-		// (4)Drop
 		{
-			name:     "cleanup notifications",
-			local:    Notifications{n0Hidden, n1Done},
+			name:     "keep hidden notification",
+			local:    Notifications{n0Hidden},
+			remote:   Notifications{n0},
 			expected: Notifications{n0Hidden},
 		},
 
-		// Testing (2)Update latest so previous tests are not impacted my
+		// (4) Drop
+		{
+			name:     "cleanup notifications",
+			local:    Notifications{n0Hidden, n1Done},
+			expected: Notifications{},
+		},
+
+		// Testing (2) Update latest so previous tests are not impacted my
 		// modified notifications.
-		// (2)Update
+		// (2) Update
 		{
 			name:     "hidden notification present in remote",
 			local:    Notifications{n0Hidden, n1Done},


### PR DESCRIPTION
The hidden state now will remove the notification from the cache when it is removed from the API.

Fix https://github.com/nobe4/gh-not/issues/138