### PR TITLE
refactor(api): drop `Do` method in the `Requestor` interface

### DIFF
--- a/internal/actions/done/done.go
+++ b/internal/actions/done/done.go
@@ -26,7 +26,7 @@ func (a *Runner) Run(n *notifications.Notification, w io.Writer) error {
 
 	n.Meta.Done = true
 
-	err := a.Client.API.Do(http.MethodDelete, n.URL, nil, nil)
+	_, err := a.Client.API.Request(http.MethodDelete, n.URL, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/actions/read/read.go
+++ b/internal/actions/read/read.go
@@ -20,7 +20,7 @@ type Runner struct {
 }
 
 func (a *Runner) Run(n *notifications.Notification, w io.Writer) error {
-	err := a.Client.API.Do(http.MethodPatch, n.URL, nil, nil)
+	_, err := a.Client.API.Request(http.MethodPatch, n.URL, nil)
 
 	// go-gh currently fails to handle HTTP-205 correctly, however it's possible
 	// to catch this case.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 )
 
-type Caller interface {
-	Do(string, string, io.Reader, interface{}) error
+type Requestor interface {
 	Request(string, string, io.Reader) (*http.Response, error)
 }

--- a/internal/api/file/file.go
+++ b/internal/api/file/file.go
@@ -18,10 +18,6 @@ func New(path string) *API {
 	return &API{path: path}
 }
 
-func (a *API) Do(verb string, url string, _ io.Reader, _ interface{}) error {
-	return nil
-}
-
 func (a *API) Request(verb string, url string, _ io.Reader) (*http.Response, error) {
 	if verb == "GET" && url == gh.DefaultEndpoint {
 		return a.readFile()

--- a/internal/api/github/github.go
+++ b/internal/api/github/github.go
@@ -5,6 +5,6 @@ import (
 	"github.com/nobe4/gh-not/internal/api"
 )
 
-func New() (api.Caller, error) {
+func New() (api.Requestor, error) {
 	return gh.DefaultRESTClient()
 }

--- a/internal/api/mock/mock.go
+++ b/internal/api/mock/mock.go
@@ -32,7 +32,7 @@ func (e *MockError) Error() string {
 	return fmt.Sprintf("mock error: %s %s: %s", e.verb, e.endpoint, e.message)
 }
 
-func New(c []Call) api.Caller {
+func New(c []Call) api.Requestor {
 	return &Mock{Calls: c}
 }
 
@@ -49,16 +49,6 @@ func (m *Mock) call(verb, endpoint string) (Call, error) {
 	m.index++
 
 	return call, nil
-}
-
-func (m *Mock) Do(verb, endpoint string, body io.Reader, out interface{}) error {
-	call, err := m.call(verb, endpoint)
-	if err != nil {
-		return err
-	}
-
-	out = call.Data
-	return call.Error
 }
 
 func (m *Mock) Request(verb, endpoint string, body io.Reader) (*http.Response, error) {

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func runSync(cmd *cobra.Command, args []string) error {
-	var caller api.Caller
+	var caller api.Requestor
 	var err error
 
 	if notificationDumpPath != "" {

--- a/internal/gh/enrichments.go
+++ b/internal/gh/enrichments.go
@@ -1,6 +1,8 @@
 package gh
 
 import (
+	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -18,8 +20,20 @@ func (c *Client) Enrich(n *notifications.Notification) error {
 		return nil
 	}
 
+	resp, err := c.API.Request(http.MethodGet, n.Subject.URL, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
 	extra := Extra{}
-	if err := c.API.Do(http.MethodGet, n.Subject.URL, nil, &extra); err != nil {
+	err = json.Unmarshal(body, &extra)
+	if err != nil {
 		return err
 	}
 

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -25,14 +25,14 @@ var (
 )
 
 type Client struct {
-	API      api.Caller
+	API      api.Requestor
 	cache    cache.ExpiringReadWriter
 	maxRetry int
 	maxPage  int
 	endpoint string
 }
 
-func NewClient(api api.Caller, cache cache.ExpiringReadWriter, config config.Endpoint) *Client {
+func NewClient(api api.Requestor, cache cache.ExpiringReadWriter, config config.Endpoint) *Client {
 	endpoint := DefaultEndpoint
 	if config.All {
 		endpoint += "?all=true"

--- a/internal/jq/jq_test.go
+++ b/internal/jq/jq_test.go
@@ -28,7 +28,7 @@ func TestFilter(t *testing.T) {
 		filter    string
 		n         notifications.Notifications
 		want      []string
-		assertErr func(t *testing.T, err error)
+		assertErr func(*testing.T, error)
 	}{
 		{
 			name:   "empty filter",

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -33,7 +33,7 @@ func New(config *config.Data) *Manager {
 	return m
 }
 
-func (m *Manager) SetCaller(caller api.Caller) {
+func (m *Manager) SetCaller(caller api.Requestor) {
 	m.client = gh.NewClient(caller, m.cache, m.config.Endpoint)
 	m.Actions = actions.Map(m.client)
 }


### PR DESCRIPTION
This shifts the responsibility to unmarshal to the caller of `Request`.