### PR TITLE
fix(repl): select all only works on filtered items

### DIFF
--- a/internal/repl/browser.go
+++ b/internal/repl/browser.go
@@ -7,7 +7,7 @@ import (
 
 func (m model) selectAll(selected bool) (tea.Model, tea.Cmd) {
 	items := []list.Item{}
-	for _, e := range m.list.Items() {
+	for _, e := range m.list.VisibleItems() {
 		if i, ok := e.(item); ok {
 			i.selected = selected
 			items = append(items, i)


### PR DESCRIPTION
Before, it was selecting from all items, but now it only selects from visible items.