### PR TITLE
test: fix CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Test
         run: |
-          set -o pipefail
-          go test -v -cover ./... | column -t -s'	'
+          go generate ./...
+          go test -race -cover ./...
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Test
-        run: go test -v -cover ./... | column -t -s'	'
+        run: |
+          set -o pipefail
+          go test -v -cover ./... | column -t -s'	'
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: |
           go generate ./...
-          go build -v ./cmd/gh-not
+          go build -v -race ./cmd/gh-not
 
   test:
     runs-on: ubuntu-latest

--- a/internal/jq/jq_test.go
+++ b/internal/jq/jq_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/nobe4/gh-not/internal/notifications"
 )
 
-func TestExample(t *testing.T) {
-	t.Fatal("TEST")
-}
-
 func notificationsEqual(a notifications.Notifications, ids []string) bool {
 	if len(a) != len(ids) {
 		return false

--- a/internal/jq/jq_test.go
+++ b/internal/jq/jq_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/nobe4/gh-not/internal/notifications"
 )
 
+func TestExample(t *testing.T) {
+	t.Fatal("TEST")
+}
+
 func notificationsEqual(a notifications.Notifications, ids []string) bool {
 	if len(a) != len(ids) {
 		return false


### PR DESCRIPTION
The current CI test fails to correctly report the failure to GitHub action, `column` eats the status code:

```shell
$ go test -v -cover ./...                   
internal/cmd/actions.go:9:12: pattern actions-help.txt: no matching files found
$ echo $?
1
$ go test -v -cover ./... | column -t -s'  '
internal/cmd/actions.go:9:12: pattern actions-help.txt: no matching files found
$ echo $?
0
```

E.g. https://github.com/nobe4/gh-not/actions/runs/10861497487/job/30143462753?pr=167