### PR TITLE
feat(gh): add `per_page` parameter for API calls

### DIFF
--- a/internal/api/file/file.go
+++ b/internal/api/file/file.go
@@ -19,7 +19,7 @@ func New(path string) *API {
 }
 
 func (a *API) Request(verb string, url string, _ io.Reader) (*http.Response, error) {
-	if verb == "GET" && url == gh.DefaultEndpoint {
+	if verb == "GET" && url == gh.DefaultUrl.String() {
 		return a.readFile()
 	}
 

--- a/internal/api/mock/calls.go
+++ b/internal/api/mock/calls.go
@@ -12,7 +12,7 @@ import (
 
 type Call struct {
 	Verb     string
-	Endpoint string
+	Url      string
 	Data     any
 	Error    error
 	Response *http.Response
@@ -20,7 +20,7 @@ type Call struct {
 
 type RawCall struct {
 	Verb     string      `json:"verb"`
-	Endpoint string      `json:"endpoint"`
+	Url      string      `json:"endpoint"`
 	Data     any         `json:"data"`
 	Error    RawError    `json:"error"`
 	Response RawResponse `json:"response"`
@@ -56,9 +56,9 @@ func LoadCallsFromFile(path string) ([]Call, error) {
 		}
 
 		call := Call{
-			Verb:     rawCall.Verb,
-			Endpoint: rawCall.Endpoint,
-			Data:     rawCall.Data,
+			Verb: rawCall.Verb,
+			Url:  rawCall.Url,
+			Data: rawCall.Data,
 			Response: &http.Response{
 				Header:     http.Header(rawCall.Response.Headers),
 				StatusCode: rawCall.Response.StatusCode,

--- a/internal/api/mock/mock.go
+++ b/internal/api/mock/mock.go
@@ -37,11 +37,11 @@ func (m *Mock) call(verb, endpoint string) (Call, error) {
 	}
 
 	call := m.Calls[m.index]
-	if (call.Verb != "" && call.Verb != verb) || (call.Endpoint != "" && call.Endpoint != endpoint) {
+	if (call.Verb != "" && call.Verb != verb) || (call.Url != "" && call.Url != endpoint) {
 		return Call{}, &MockError{
 			verb,
 			endpoint,
-			fmt.Sprintf("unexpected call: mismatch, expected [%s %s]", call.Verb, call.Endpoint),
+			fmt.Sprintf("unexpected call: mismatch, expected [%s %s]", call.Verb, call.Url),
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,11 @@ type Endpoint struct {
 	// This will cap the `?page=X` parameter in the GitHub API.
 	// See https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#list-notifications-for-the-authenticated-user
 	MaxPage int `mapstructure:"max_page"`
+
+	// The number of notifications to fetch per page.
+	// This maps to `?per_page=X` in the GitHub API.
+	// See https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#list-notifications-for-the-authenticated-user
+	PerPage int `mapstructure:"per_page"`
 }
 
 // Cache is the configuration for the cache file.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -9,6 +9,7 @@ var Defaults = map[string]any{
 	"endpoint.all":       true,
 	"endpoint.max_retry": 10,
 	"endpoint.max_page":  5,
+	"endpoint.per_page":  100,
 
 	"view.height": 40,
 

--- a/internal/gh/errors.go
+++ b/internal/gh/errors.go
@@ -9,10 +9,10 @@ import (
 var decodeError error = errors.New("decode error")
 
 type RetryError struct {
-	verb     string
-	endpoint string
+	verb string
+	url  string
 }
 
 func (e RetryError) Error() string {
-	return fmt.Sprintf("retry exceeded for %s %s", e.verb, e.endpoint)
+	return fmt.Sprintf("retry exceeded for %s %s", e.verb, e.url)
 }

--- a/internal/gh/errors_test.go
+++ b/internal/gh/errors_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestRetryError(t *testing.T) {
 	e := RetryError{
-		verb:     "verb",
-		endpoint: "endpoint",
+		verb: "verb",
+		url:  "endpoint",
 	}
 	want := "retry exceeded for verb endpoint"
 	got := e.Error()

--- a/internal/gh/errors_test.go
+++ b/internal/gh/errors_test.go
@@ -5,9 +5,9 @@ import "testing"
 func TestRetryError(t *testing.T) {
 	e := RetryError{
 		verb: "verb",
-		url:  "endpoint",
+		url:  "url",
 	}
-	want := "retry exceeded for verb endpoint"
+	want := "retry exceeded for verb url"
 	got := e.Error()
 
 	if got != want {


### PR DESCRIPTION
This also refactors the `defaultEndpoint` to use a full URL.

Fix #171 