### PR TITLE
feat(cache): store RefreshedAt information in the Wrapper

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/nobe4/gh-not/internal/actions"
 	"github.com/nobe4/gh-not/internal/api"
@@ -73,6 +74,8 @@ func (m *Manager) refreshNotifications() error {
 	m.Notifications = notifications.Sync(m.Notifications, remoteNotifications)
 	m.Notifications = m.Notifications.Uniq()
 	m.Notifications, err = m.Enrich(m.Notifications)
+
+	m.Cache.SetRefreshedAt(time.Now())
 
 	return err
 }


### PR DESCRIPTION
This removes the need for using the FS information when checking when
the cache has been last refreshed. Calling `SetRefreshedAt` will
manually update this value before saving it.

cc https://github.com/nobe4/gh-not/issues/169