### PR TITLE
feat(cache): move the expiration logic out

### DIFF
--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -30,13 +30,13 @@ var (
 
 type Client struct {
 	API      api.Requestor
-	cache    cache.ExpiringReadWriter
+	cache    cache.RefreshReadWriter
 	maxRetry int
 	maxPage  int
 	url      string
 }
 
-func NewClient(api api.Requestor, cache cache.ExpiringReadWriter, config config.Endpoint) *Client {
+func NewClient(api api.Requestor, cache cache.RefreshReadWriter, config config.Endpoint) *Client {
 	url := DefaultUrl
 
 	query := url.Query()


### PR DESCRIPTION
This closes the loop on #169 by moving the expiration logic into the manager instead of in the cache. While the cache's configuration conserves the `ttl_in_hours`, the logic is now handled in the manager. This simplifies the cache to implement just a RefreshReadWriter.