### PR TITLE
fix(cache): catch nil wrap expiration date

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -68,6 +68,10 @@ func (c *FileCache) Refresh(t time.Time) {
 }
 
 func (c *FileCache) RefreshedAt() time.Time {
+	if c.wrap == nil {
+		return time.Unix(0, 0)
+	}
+
 	return c.wrap.RefreshedAt
 }
 


### PR DESCRIPTION
Fix case when cache is missing and `wrap` is nil.

```
$ go run cmd/gh-not/main.go -c config.local.yaml -v4
time=2024-09-29T20:11:08.443+02:00 level=DEBUG msg="loading configuration" path=config.local.yaml
time=2024-09-29T20:11:08.443+02:00 level=DEBUG msg="loading default configuration"
time=2024-09-29T20:11:08.443+02:00 level=DEBUG msg="setting config name and path" path=config.local.yaml
time=2024-09-29T20:11:08.444+02:00 level=DEBUG msg="cache doesn't exist" path=./cache-test.json
time=2024-09-29T20:11:08.444+02:00 level=INFO msg="Loaded notifications" count=0

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x1044e8964]

goroutine 1 [running]:
github.com/nobe4/gh-not/internal/cache.(*FileCache).RefreshedAt(0x104728d78?)
	[redacted]/gh-not/internal/cache/cache.go:71 +0x4
```