### PR TITLE
fix(repl): items store their index in the list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-// Needed until https://github.com/charmbracelet/bubbles/pull/574 is merged
-replace github.com/charmbracelet/bubbles v0.18.0 => github.com/nobe4/bubbles v0.18.1
-
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v0.18.0 h1:PYv1A036luoBGroX6VWjQIE9Syf2Wby2oOl/39KLfy0=
+github.com/charmbracelet/bubbles v0.18.0/go.mod h1:08qhZhtIwzgrtBjAcJnij1t1H0ZRjwHyGsy6AL11PSw=
 github.com/charmbracelet/bubbletea v1.1.1 h1:KJ2/DnmpfqFtDNVTvYZ6zpPFL9iRCRr0qqKOCvppbPY=
 github.com/charmbracelet/bubbletea v1.1.1/go.mod h1:9Ogk0HrdbHolIKHdjfFpyXJmiCzGwy+FesYkZr7hYU4=
 github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
@@ -76,8 +78,6 @@ github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
-github.com/nobe4/bubbles v0.18.1 h1:SINsSTt1tJUKGHifA6ipy8tM2eTnDKSxOHBLzumwOPE=
-github.com/nobe4/bubbles v0.18.1/go.mod h1:z199e1Fc5JXB44at0N3xsoBgbQh2rFAFw35+F4/wv+8=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/repl/browser.go
+++ b/internal/repl/browser.go
@@ -1,17 +1,18 @@
 package repl
 
 import (
-	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 func (m model) selectAll(selected bool) (tea.Model, tea.Cmd) {
-	items := []list.Item{}
+	cmds := []tea.Cmd{}
+
 	for _, e := range m.list.VisibleItems() {
 		if i, ok := e.(item); ok {
 			i.selected = selected
-			items = append(items, i)
+			cmds = append(cmds, m.list.SetItem(i.index, i))
 		}
 	}
-	return m, m.list.SetItems(items)
+
+	return m, tea.Sequence(cmds...)
 }

--- a/internal/repl/item.go
+++ b/internal/repl/item.go
@@ -11,6 +11,9 @@ import (
 )
 
 type item struct {
+	// It's not possible to rely on bubbles/list's model to get the global index
+	// of an item, so we have to manage it manually.
+	index        int
 	notification *notifications.Notification
 	selected     bool
 }

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -56,7 +56,9 @@ func Init(n notifications.Notifications, actions actions.ActionsMap, keymap conf
 	return nil
 }
 
-func (m model) Init() tea.Cmd { return nil }
+func (m model) Init() tea.Cmd {
+	return m.setIndexes()
+}
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	slog.Debug("update", "msg", msg)


### PR DESCRIPTION
After battling against bubble's incomplete interface, I've decided to store the list's index manually and do the logic myself.

The indexes are computed each time the list change size (i.e. after executing a command) and used whenever changing an item is necessary.

This prevent the list of items from being replaced during selecting all as described in https://github.com/nobe4/gh-not/issues/175#issuecomment-2381476328

It removes the dependency on https://github.com/charmbracelet/bubbles/pull/574.

Fix #175