### PR TITLE
feat(actions): allow passing string parameters to actions

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -29,5 +29,5 @@ func Map(client *gh.Client) ActionsMap {
 }
 
 type Runner interface {
-	Run(*notifications.Notification, io.Writer) error
+	Run(*notifications.Notification, []string, io.Writer) error
 }

--- a/internal/actions/debug/debug.go
+++ b/internal/actions/debug/debug.go
@@ -6,6 +6,7 @@ package debug
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/nobe4/gh-not/internal/colors"
 	"github.com/nobe4/gh-not/internal/notifications"
@@ -13,8 +14,8 @@ import (
 
 type Runner struct{}
 
-func (_ *Runner) Run(n *notifications.Notification, w io.Writer) error {
-	fmt.Fprint(w, colors.Yellow("DEBUG ")+n.String())
+func (_ *Runner) Run(n *notifications.Notification, args []string, w io.Writer) error {
+	fmt.Fprint(w, colors.Yellow("DEBUG ")+n.String()+" "+strings.Join(args, ", "))
 
 	return nil
 }

--- a/internal/actions/done/done.go
+++ b/internal/actions/done/done.go
@@ -21,7 +21,7 @@ type Runner struct {
 	Client *gh.Client
 }
 
-func (a *Runner) Run(n *notifications.Notification, w io.Writer) error {
+func (a *Runner) Run(n *notifications.Notification, _ []string, w io.Writer) error {
 	slog.Debug("marking notification as done", "notification", n)
 
 	n.Meta.Done = true

--- a/internal/actions/hide/hide.go
+++ b/internal/actions/hide/hide.go
@@ -15,7 +15,7 @@ import (
 
 type Runner struct{}
 
-func (_ *Runner) Run(n *notifications.Notification, w io.Writer) error {
+func (_ *Runner) Run(n *notifications.Notification, _ []string, w io.Writer) error {
 	slog.Debug("marking notification as hidden", "notification", n.Id)
 
 	n.Meta.Hidden = true

--- a/internal/actions/open/open.go
+++ b/internal/actions/open/open.go
@@ -18,7 +18,7 @@ type Runner struct {
 	Client *gh.Client
 }
 
-func (a *Runner) Run(n *notifications.Notification, w io.Writer) error {
+func (a *Runner) Run(n *notifications.Notification, _ []string, w io.Writer) error {
 	slog.Debug("open notification in browser", "notification", n)
 
 	browser := browser.New("", w, w)

--- a/internal/actions/pass/pass.go
+++ b/internal/actions/pass/pass.go
@@ -11,6 +11,6 @@ import (
 
 type Runner struct{}
 
-func (_ *Runner) Run(n *notifications.Notification, _ io.Writer) error {
+func (_ *Runner) Run(n *notifications.Notification, _ []string, _ io.Writer) error {
 	return nil
 }

--- a/internal/actions/print/print.go
+++ b/internal/actions/print/print.go
@@ -12,7 +12,7 @@ import (
 
 type Runner struct{}
 
-func (_ *Runner) Run(n *notifications.Notification, w io.Writer) error {
+func (_ *Runner) Run(n *notifications.Notification, _ []string, w io.Writer) error {
 	if !n.Meta.Hidden {
 		fmt.Fprint(w, n.String())
 	}

--- a/internal/actions/read/read.go
+++ b/internal/actions/read/read.go
@@ -19,7 +19,7 @@ type Runner struct {
 	Client *gh.Client
 }
 
-func (a *Runner) Run(n *notifications.Notification, w io.Writer) error {
+func (a *Runner) Run(n *notifications.Notification, _ []string, w io.Writer) error {
 	_, err := a.Client.API.Request(http.MethodPatch, n.URL, nil)
 
 	// go-gh currently fails to handle HTTP-205 correctly, however it's possible

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -128,7 +128,7 @@ func (m *Manager) Apply() error {
 				continue
 			}
 
-			if err := runner.Run(notification, os.Stdout); err != nil {
+			if err := runner.Run(notification, nil, os.Stdout); err != nil {
 				slog.Error("action failed", "action", rule.Action, "err", err)
 			}
 			fmt.Fprintln(os.Stdout, "")

--- a/internal/repl/handlers.go
+++ b/internal/repl/handlers.go
@@ -108,7 +108,7 @@ func (m *model) handleBrowsing(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keymap.Open):
 		current, ok := m.list.SelectedItem().(item)
 		if ok {
-			m.actions["open"].Run(current.notification, os.Stderr)
+			m.actions["open"].Run(current.notification, nil, os.Stderr)
 		}
 
 	case key.Matches(msg, m.keymap.CommandMode):

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -13,9 +13,9 @@ import (
 )
 
 type model struct {
-	keymap        Keymap
-	actions       actions.ActionsMap
-	currentRunner actions.Runner
+	keymap     Keymap
+	actions    actions.ActionsMap
+	currentRun Run
 
 	showHelp bool
 	list     list.Model


### PR DESCRIPTION
This prepares later work for #187. Passing parameter will enable additional customization in the REPL and later in the config as well.

Only the `Debug` action currently uses this new parameter, to confirm it's receiving it correctly.

Also have to do some workaround a bubble limitation, see https://github.com/charmbracelet/bubbles/pull/630