### PR TITLE
feat(config): enable passing arguments to the rule

### DIFF
--- a/internal/config/rule.go
+++ b/internal/config/rule.go
@@ -38,6 +38,9 @@ type Rule struct {
 	// Action is the action to take on the filtered notifications.
 	// See github.com/nobe4/internal/actions for list of available actions.
 	Action string `mapstructure:"action"`
+
+	// Args is the arguments to pass to the Action.
+	Args []string `mapstructure:"args"`
 }
 
 // Test tests the rule for correctness.

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -128,7 +128,7 @@ func (m *Manager) Apply() error {
 				continue
 			}
 
-			if err := runner.Run(notification, nil, os.Stdout); err != nil {
+			if err := runner.Run(notification, rule.Args, os.Stdout); err != nil {
 				slog.Error("action failed", "action", rule.Action, "err", err)
 			}
 			fmt.Fprintln(os.Stdout, "")


### PR DESCRIPTION
This build on #188 and allow to specify arguments in the rules.

E.g.

```yaml
rules:
  - name: test
    action: debug
    args: ["a", "b"]
```

cc #187