### PR TITLE
fix(manager): relax enrichment failure

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -96,7 +96,7 @@ func (m *Manager) Enrich(ns notifications.Notifications) (notifications.Notifica
 			// Enrichement of a single Notifications should not prevent the
 			// enrichment to continue.
 			// TODO: suggest to re-run the enrichment
-			slog.Warn("failed to enrich notification", "notification", n.Id)
+			slog.Warn("failed to enrich notification", "notification", n.Id, "error", err.Error())
 		}
 
 		ns[i] = n

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -93,7 +93,10 @@ func (m *Manager) Enrich(ns notifications.Notifications) (notifications.Notifica
 		}
 
 		if err := m.client.Enrich(n); err != nil {
-			return nil, err
+			// Enrichement of a single Notifications should not prevent the
+			// enrichment to continue.
+			// TODO: suggest to re-run the enrichment
+			slog.Warn("failed to enrich notification", "notification", n.Id)
 		}
 
 		ns[i] = n


### PR DESCRIPTION
If any notification fails to enrich, it should not prevent the others from continuing being enriched as well.