### PR TITLE
feat(gh): add error information in the output

### DIFF
--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -125,7 +125,7 @@ func (c *Client) retry(verb, endpoint string, body io.Reader) ([]*notifications.
 		}
 
 		if isRetryable(err) {
-			slog.Warn("endpoint failed with retryable error", "endpoint", endpoint, "retry left", i)
+            slog.Warn("endpoint failed with retryable error", "error", err, "endpoint", endpoint, "retry left", i)
 			continue
 		}
 

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -125,7 +125,7 @@ func (c *Client) retry(verb, endpoint string, body io.Reader) ([]*notifications.
 		}
 
 		if isRetryable(err) {
-            slog.Warn("endpoint failed with retryable error", "error", err, "endpoint", endpoint, "retry left", i)
+			slog.Warn("endpoint failed with retryable error", "error", err, "endpoint", endpoint, "retry left", i)
 			continue
 		}
 


### PR DESCRIPTION
This helps to get a sense of why a request is failing and why it's retrying.