### PR TITLE
Add Assignees, Reviewers and ReviewersTeams

### DIFF
--- a/internal/gh/enrichments.go
+++ b/internal/gh/enrichments.go
@@ -10,9 +10,12 @@ import (
 )
 
 type ThreadExtra struct {
-	User    notifications.User `json:"user"`
-	State   string             `json:"state"`
-	HtmlUrl string             `json:"html_url"`
+	User           notifications.User   `json:"user"`
+	State          string               `json:"state"`
+	HtmlUrl        string               `json:"html_url"`
+	Assignees      []notifications.User `json:"assignees"`
+	Reviewers      []notifications.User `json:"requested_reviewers"`
+	ReviewersTeams []notifications.Team `json:"requested_teams"`
 }
 
 func (c *Client) Enrich(n *notifications.Notification) error {
@@ -27,6 +30,9 @@ func (c *Client) Enrich(n *notifications.Notification) error {
 	n.Author = threadExtra.User
 	n.Subject.State = threadExtra.State
 	n.Subject.HtmlUrl = threadExtra.HtmlUrl
+	n.Assignees = threadExtra.Assignees
+	n.Reviewers = threadExtra.Reviewers
+	n.ReviewersTeams = threadExtra.ReviewersTeams
 
 	LastCommentor, err := c.getLastCommentor(n)
 	if err != nil {

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -27,8 +27,11 @@ type Notification struct {
 	Subject    Subject    `json:"subject"`
 
 	// Enriched API fields
-	Author          User `json:"author"`
-	LatestCommentor User `json:"latest_commentor"`
+	Author          User   `json:"author"`
+	LatestCommentor User   `json:"latest_commentor"`
+	Assignees       []User `json:"assignees"`
+	Reviewers       []User `json:"requested_reviewers"`
+	ReviewersTeams  []Team `json:"requested_teams"`
 
 	// gh-not specific fields
 	// Those fields are not part of the GitHub API and will persist between
@@ -80,6 +83,11 @@ type Repository struct {
 type User struct {
 	Login string `json:"login"`
 	Type  string `json:"type"`
+}
+
+type Team struct {
+	Name string `json:"name"`
+	Id   uint   `json:"id"`
 }
 
 func (n Notifications) Equal(others Notifications) bool {


### PR DESCRIPTION
This PR adds assignees, reviewers, and review teams to be able to filter on them

For assignees and reviewers it's just a list of Users and for review teams I add the Team struct and have list of those. 

Fixes #200 