### PR TITLE
fix(config): init bootstrap the config folder

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -53,9 +53,10 @@ func initConfig() error {
 	slog.Debug("creating initial config file", "path", configPathFlag)
 
 	initialConfig, initialPath := configPkg.Default(configPathFlag)
+	initialConfigDir := filepath.Dir(initialPath)
 
-	if err := os.MkdirAll(filepath.Dir(initialPath), os.ModePerm); err != nil {
-		slog.Error("Failed to create config directory", "path", configPathFlag, "err", err)
+	if err := os.MkdirAll(initialConfigDir, os.ModePerm); err != nil {
+		slog.Error("Failed to create config directory", "path", initialConfigDir, "err", err)
 		return err
 	}
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	configPkg "github.com/nobe4/gh-not/internal/config"
 	"github.com/spf13/cobra"
@@ -51,11 +52,18 @@ func runConfig(cmd *cobra.Command, args []string) error {
 func initConfig() error {
 	slog.Debug("creating initial config file", "path", configPathFlag)
 
-	if err := configPkg.Default(configPathFlag).WriteConfig(); err != nil {
+	initialConfig, initialPath := configPkg.Default(configPathFlag)
+
+	if err := os.MkdirAll(filepath.Dir(initialPath), os.ModePerm); err != nil {
+		slog.Error("Failed to create config directory", "path", configPathFlag, "err", err)
+		return err
+	}
+
+	if err := initialConfig.WriteConfig(); err != nil {
 		slog.Error("Failed to save initial config", "err", err)
 		return err
 	}
-	fmt.Printf("Initial config saved to %s\n", configPathFlag)
+	fmt.Printf("Initial config saved to %s\n", initialPath)
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"io/fs"
 	"log/slog"
+	"path/filepath"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -72,8 +73,13 @@ type View struct {
 	Height int `mapstructure:"height"`
 }
 
-func Default(path string) *viper.Viper {
+func Default(path string) (*viper.Viper, string) {
 	slog.Debug("loading default configuration")
+	if path == "" {
+		path = filepath.Join(ConfigDir(), "config.yaml")
+		slog.Debug("path is empty, setting default path", "default path", path)
+	}
+
 	v := viper.New()
 
 	for key, value := range Defaults {
@@ -81,20 +87,16 @@ func Default(path string) *viper.Viper {
 	}
 
 	slog.Debug("setting config name and path", "path", path)
-	if path == "" {
-		v.SetConfigName("config")
-		v.SetConfigType("yaml")
-		v.AddConfigPath(ConfigDir())
-	} else {
-		v.SetConfigFile(path)
-	}
 
-	return v
+	v.SetConfigFile(path)
+
+	return v, path
 }
 
 func New(path string) (*Config, error) {
+	v, path := Default(path)
 	slog.Debug("loading configuration", "path", path)
-	c := &Config{viper: Default(path), Path: path}
+	c := &Config{viper: v, Path: path}
 
 	if err := c.viper.ReadInConfig(); err != nil {
 		viperNotFoundError := viper.ConfigFileNotFoundError{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,7 +99,7 @@ func New(path string) (*Config, error) {
 	c := &Config{viper: v, Path: path}
 
 	if err := c.viper.ReadInConfig(); err != nil {
-		viperNotFoundError := viper.ConfigFileNotFoundError{}
+		var viperNotFoundError viper.ConfigFileNotFoundError
 		if errors.As(err, &viperNotFoundError) ||
 			errors.Is(err, fs.ErrNotExist) {
 			slog.Warn("Config file not found, using default")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,7 +97,8 @@ func New(path string) (*Config, error) {
 	c := &Config{viper: Default(path), Path: path}
 
 	if err := c.viper.ReadInConfig(); err != nil {
-		if errors.Is(err, viper.ConfigFileNotFoundError{}) ||
+		viperNotFoundError := viper.ConfigFileNotFoundError{}
+		if errors.As(err, &viperNotFoundError) ||
 			errors.Is(err, fs.ErrNotExist) {
 			slog.Warn("Config file not found, using default")
 		} else {


### PR DESCRIPTION
Fixes #223

- Fixing how the error is compared if viper can't read the config
- Exposing the initial path for new config
- Creating the config folder if it doesn't exist

Closes #224 (thanks tho for the effort @ccoVeille :pray:)