### PR TITLE
ci: enable golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,19 @@ jobs:
             exit 1
           fi
 
+  golangci-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Generate embed file
+        run: go generate ./...
+
+      - name: Launch golangci-lint
+        uses: golangci/golangci-lint-action@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+---
+# Ref: https://golangci-lint.run/usage/configuration/
+# Inspired by https://github.com/ccoVeille/golangci-lint-config-examples/
+linters:
+  enable:
+    - revive
+    - gci
+    - thelper
+    - mirror
+    - usestdlibvars
+    - misspell
+    - dupword
+    - loggercheck
+    - fatcontext
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - localmodule
+
+  revive:
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+
+  misspell:
+    locale: US


### PR DESCRIPTION
Currently 43 errors, more rules could be enabled.

But let's start with these ones.

Fixes:
- #221 