### PR TITLE
feat(gh): allow multiple hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,65 @@ section](#automatic-fetching).
 The other commands are used to interact with the local cache. It uses `gh
 api`-equivalent to modify the notifications on GitHub's side.
 
-# Configure
+# Authentication
+
+`gh-not` uses `gh`'s built-in authentication, meaning that if `gh` works,
+`gh-not` should work.
+
+If you want to use a specific PAT, you can do so with the environment variable
+`GH_TOKEN`. The PAT requires the scopes: `notifications`, and `repo`.
+
+`gh-not` also respects `GH_HOST` and `GH_ENTERPRISE_TOKEN` if you need to use a
+non-`github.com` host.
+
+E.g.:
+
+```bash
+# gh's authentication for github.com
+gh-not ...
+
+# Using a PAT for github.com.
+GH_TOKEN=XXX gh-not ...
+
+# gh's authentication for ghe.io
+GH_HOST=ghe.io gh-not ...
+
+# Using a PAT for ghe.io
+GH_HOST=ghe.io GH_ENTERPRISE_TOKEN=XXX gh-not ...
+```
+
+See the [`gh` environment documentation](https://cli.github.com/manual/gh_help_environment).
+
+> [!IMPORANT]
+> If you plan on using `gh-not` with more than one host, you might want to
+> create a separate cache for it. See [cache](#cache).
+
+# Configuration
+
+## Cache
+
+The cache is where the notifications are locally stored.
+
+It contains 2 fields:
+
+- `path`: the path to the JSON file.
+
+- `TTLInHours`: how long before the cache needs to be refreshed.
+
+If you use multiple hosts, you might want to have separate configurations and
+caches to prevent overrides:
+
+```yaml
+# config.github.yaml
+cache:
+  path: cache.github.json
+
+# config.gheio.yaml
+cache:
+  path: cache.gheio.json
+```
+
+## Rules
 
 The configuration file contains the rules to apply to the notifications. Each
 rule contains three fields:

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ api`-equivalent to modify the notifications on GitHub's side.
 If you want to use a specific PAT, you can do so with the environment variable
 `GH_TOKEN`. The PAT requires the scopes: `notifications`, and `repo`.
 
-`gh-not` also respects `GH_HOST` and `GH_ENTERPRISE_TOKEN` if you need to use a
-non-`github.com` host.
-
 E.g.:
 
 ```bash
@@ -76,7 +73,14 @@ gh-not ...
 
 # Using a PAT for github.com.
 GH_TOKEN=XXX gh-not ...
+```
 
+`gh-not` also respects `GH_HOST` and `GH_ENTERPRISE_TOKEN` if you need to use a
+non-`github.com` host.
+
+E.g.:
+
+```bash
 # gh's authentication for ghe.io
 GH_HOST=ghe.io gh-not ...
 
@@ -103,17 +107,27 @@ It contains 2 fields:
 - `TTLInHours`: how long before the cache needs to be refreshed.
 
 If you use multiple hosts, you might want to have separate configurations and
-caches to prevent overrides:
+caches to prevent overrides. Create one config file per host you want to use and
+point the cache's path to a _different file_.
 
-```yaml
-# config.github.yaml
-cache:
-  path: cache.github.json
+E.g.
 
-# config.gheio.yaml
-cache:
-  path: cache.gheio.json
-```
+- `config.github.yaml`
+    ```yaml
+    cache:
+      path: cache.github.json
+    ...
+    ```
+
+    Use it with `gh-not --config config.github.yaml`.
+
+- `config.gheio.yaml `
+    ```yaml
+    cache:
+      path: cache.gheio.json
+    ...
+    ```
+    Use it with `gh-not --config config.gheio.yaml`.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ GH_HOST=ghe.io GH_ENTERPRISE_TOKEN=XXX gh-not ...
 
 See the [`gh` environment documentation](https://cli.github.com/manual/gh_help_environment).
 
-> [!IMPORANT]
+> [!IMPORTANT]
 > If you plan on using `gh-not` with more than one host, you might want to
 > create a separate cache for it. See [cache](#cache).
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,5 +6,5 @@ import (
 )
 
 type Requestor interface {
-	Request(method string, url string, body io.Reader) (*http.Response, error)
+	Request(method string, path string, body io.Reader) (*http.Response, error)
 }

--- a/internal/api/file/file.go
+++ b/internal/api/file/file.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-
-	"github.com/nobe4/gh-not/internal/gh"
 )
 
 type API struct {
@@ -19,7 +17,7 @@ func New(path string) *API {
 }
 
 func (a *API) Request(verb string, url string, _ io.Reader) (*http.Response, error) {
-	if verb == "GET" && url == gh.DefaultURL.String() {
+	if verb == "GET" {
 		return a.readFile()
 	}
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -42,6 +42,8 @@ func NewFileCache(path string) *FileCache {
 }
 
 func (c *FileCache) Read(out any) error {
+	slog.Debug("Reading cache", "path", c.path)
+
 	content, err := os.ReadFile(c.path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -95,6 +95,8 @@ func parse(r *http.Response) ([]*notifications.Notification, string, error) {
 	return n, nextPageLink(&r.Header), nil
 }
 
+// TODO: this should only return the path, as the full URL is not expected in
+// the Request.
 func nextPageLink(h *http.Header) string {
 	for _, m := range linkRE.FindAllStringSubmatch(h.Get("Link"), -1) {
 		if len(m) > 2 && m[2] == "next" {

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -19,29 +19,20 @@ import (
 	"github.com/nobe4/gh-not/internal/notifications"
 )
 
-var (
-	linkRE = regexp.MustCompile(`<([^>]+)>;\s*rel="([^"]+)"`)
-
-	//nolint:gochecknoglobals // This is used as a default in a couple of places.
-	DefaultURL = url.URL{
-		Scheme: "https",
-		Host:   "api.github.com",
-		Path:   "/notifications",
-	}
-)
+var linkRE = regexp.MustCompile(`<([^>]+)>;\s*rel="([^"]+)"`)
 
 type Client struct {
 	API      api.Requestor
 	cache    cache.RefreshReadWriter
 	maxRetry int
 	maxPage  int
-	url      string
+	path     string
 }
 
 func NewClient(api api.Requestor, cache cache.RefreshReadWriter, config config.Endpoint) *Client {
-	url := DefaultURL
+	path := url.URL{Path: "notifications"}
 
-	query := url.Query()
+	query := path.Query()
 	if config.All {
 		query.Set("all", "true")
 	}
@@ -50,14 +41,14 @@ func NewClient(api api.Requestor, cache cache.RefreshReadWriter, config config.E
 		query.Set("per_page", strconv.Itoa(config.PerPage))
 	}
 
-	url.RawQuery = query.Encode()
+	path.RawQuery = query.Encode()
 
 	return &Client{
 		API:      api,
 		cache:    cache,
 		maxRetry: config.MaxRetry,
 		maxPage:  config.MaxPage,
-		url:      url.String(),
+		path:     path.String(),
 	}
 }
 
@@ -152,7 +143,7 @@ func (c *Client) paginate() (notifications.Notifications, error) {
 	var err error
 
 	pageLeft := c.maxPage
-	endpoint := c.url
+	endpoint := c.path
 
 	for endpoint != "" && pageLeft > 0 {
 		slog.Info("API REST request", "endpoint", endpoint, "page_left", pageLeft)

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -160,34 +160,34 @@ func TestIsRetryable(t *testing.T) {
 
 func TestNewClient(t *testing.T) {
 	tests := []struct {
-		name    string
-		all     bool
-		perPage int
-		wantURL string
+		name     string
+		all      bool
+		perPage  int
+		wantPath string
 	}{
 		{
-			name:    "default",
-			all:     false,
-			perPage: 0,
-			wantURL: "https://api.github.com/notifications",
+			name:     "default",
+			all:      false,
+			perPage:  0,
+			wantPath: "notifications",
 		},
 		{
-			name:    "all",
-			all:     true,
-			perPage: 0,
-			wantURL: "https://api.github.com/notifications?all=true",
+			name:     "all",
+			all:      true,
+			perPage:  0,
+			wantPath: "notifications?all=true",
 		},
 		{
-			name:    "10 per page",
-			all:     false,
-			perPage: 10,
-			wantURL: "https://api.github.com/notifications?per_page=10",
+			name:     "10 per page",
+			all:      false,
+			perPage:  10,
+			wantPath: "notifications?per_page=10",
 		},
 		{
-			name:    "all and 10 per page",
-			all:     true,
-			perPage: 10,
-			wantURL: "https://api.github.com/notifications?all=true&per_page=10",
+			name:     "all and 10 per page",
+			all:      true,
+			perPage:  10,
+			wantPath: "notifications?all=true&per_page=10",
 		},
 	}
 
@@ -202,8 +202,8 @@ func TestNewClient(t *testing.T) {
 			client := NewClient(nil, nil, *config)
 
 			// only testing the result URL, the rest is stored verbatim.
-			if client.path != test.wantURL {
-				t.Errorf("expected %s, got %s", test.wantURL, client.path)
+			if client.path != test.wantPath {
+				t.Errorf("expected %s, got %s", test.wantPath, client.path)
 			}
 		})
 	}

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -105,7 +105,7 @@ func mockClient(c []mock.Call) (*Client, *mock.Mock) {
 
 	return &Client{
 		API:      mock,
-		url:      endpoint,
+		path:     endpoint,
 		maxRetry: 100,
 		maxPage:  100,
 	}, mock
@@ -202,8 +202,8 @@ func TestNewClient(t *testing.T) {
 			client := NewClient(nil, nil, *config)
 
 			// only testing the result URL, the rest is stored verbatim.
-			if client.url != test.wantURL {
-				t.Errorf("expected %s, got %s", test.wantURL, client.url)
+			if client.path != test.wantURL {
+				t.Errorf("expected %s, got %s", test.wantURL, client.path)
 			}
 		})
 	}

--- a/test/integration/000/calls.json
+++ b/test/integration/000/calls.json
@@ -1,7 +1,7 @@
 [
   {
     "verb": "GET",
-    "endpoint": "https://api.github.com/notifications?all=true",
+    "endpoint": "notifications?all=true",
     "response": {
       "status_code": 200,
       "body": []

--- a/test/integration/001/calls.json
+++ b/test/integration/001/calls.json
@@ -1,7 +1,7 @@
 [
   {
     "verb": "GET",
-    "endpoint": "https://api.github.com/notifications?all=true",
+    "endpoint": "notifications?all=true",
     "response": {
       "status_code": 200,
       "headers": {

--- a/test/integration/002/calls.json
+++ b/test/integration/002/calls.json
@@ -1,7 +1,7 @@
 [
   {
     "verb": "GET",
-    "endpoint": "https://api.github.com/notifications?all=true",
+    "endpoint": "notifications?all=true",
     "response": {
       "status_code": 200,
       "headers": {},


### PR DESCRIPTION
This PR attempts to bring multi-host capabilities in `gh-not`.

## Implementation

It removes the hardcoded default URL and instead relies on `go-gh` self-discovery mechanism.

The `Request` doesn't actually need a full URL; a path is enough: https://github.com/cli/go-gh/blob/13104ed7b2db4b8c1a83de4248ddfaaab7682916/pkg/api/rest_client.go#L75-L77

It also builds the full REST URL dynamically: https://github.com/cli/go-gh/blob/13104ed7b2db4b8c1a83de4248ddfaaab7682916/pkg/api/rest_client.go#L153-L172

The way to use it is similar to what `gh` expect. E.g. for ghe.io:

```shell
# with gh configured with ghe.io
GH_DEBUG=api \
GH_HOST=ghe.io \
    go run ./cmd/gh-not/main.go -c config.gheio.yaml -v4 sync -r force

# with a custom PAT
GH_DEBUG=api \
GH_HOST=ghe.io \
GH_ENTERPRISE_TOKEN=[REDACTED] \
    go run ./cmd/gh-not/main.go -c config.gheio.yaml -v4 sync -r force
```

⚠️ it's recommended to have a separate cache for the separate host, to prevent conflicts.

## Tasks:

- [x] Have @watermarkhu do a test to confirm that it's working.
- [x] Update documentation to explain this.

cc #235