### PR TITLE
feat(version): allow custom build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
     go build ./cmd/gh-not
     ```
 
+    See [`version.go`](./internal/version/version.go) for custom build info.
+
 # Getting started
 
 Run the following commands to get started and see the available commands and

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,15 +5,27 @@ import (
 	"runtime/debug"
 )
 
+const template = "%s (%s) built at %s\nhttps://github.com/nobe4/gh-not/releases/tag/%s"
+
+// Leaving them global to allow setting them via ldflags.
+// E.g. go build ./cmd/gh-not -ldflags "-X github.com/nobe4/gh-not/internal/version.tag=0.1.0".
+//
+//nolint:gochecknoglobals // see above.
+var (
+	tag    = "UNSET_TAG"
+	commit = "UNSET_COMMIT"
+	date   = "UNSET_DATE"
+)
+
 func String() string {
-	const template = "%s (%s) built at %s\nhttps://github.com/nobe4/gh-not/releases/tag/%s"
+	if tag == "UNSET_TAG" && commit == "UNSET_COMMIT" && date == "UNSET_DATE" {
+		parseBuildInfo()
+	}
 
-	var (
-		tag    = "UNSET_TAG"
-		commit = "UNSET_COMMIT"
-		date   = "UNSET_DATE"
-	)
+	return fmt.Sprintf(template, tag, commit, date, tag)
+}
 
+func parseBuildInfo() {
 	info, ok := debug.ReadBuildInfo()
 
 	if ok {
@@ -29,6 +41,4 @@ func String() string {
 			}
 		}
 	}
-
-	return fmt.Sprintf(template, tag, commit, date, tag)
 }


### PR DESCRIPTION
Requested by @tebriel, to build the binary with custom information.

This takes the approach of ignoring the debug info if any of the default value is changed.

e.g.

    $ go build --ldflags="-w -s" ./cmd/gh-not && ./gh-not --version
    gh-not version v0.6.1+dirty (92248254838460978b3af005c350eba3463050b9) built at 2025-02-14T18:41:31Z
    https://github.com/nobe4/gh-not/releases/tag/v0.6.1+dirty

    $ go build --ldflags="-w -s -X github.com/nobe4/gh-not/internal/version.tag=0.1.0" ./cmd/gh-not && ./gh-not --version
    gh-not version 0.1.0 (UNSET_COMMIT) built at UNSET_DATE
    https://github.com/nobe4/gh-not/releases/tag/0.1.0