### PR TITLE
feat(config): enable $ENVIRONMENT-based path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/viper"
@@ -82,6 +83,9 @@ func Default(path string) (*viper.Viper, string) {
 	if path == "" {
 		path = filepath.Join(Dir(), "config.yaml")
 		slog.Debug("path is empty, setting default path", "default path", path)
+	} else {
+		// Allows to use $HOME in the config path.
+		path = os.ExpandEnv(path)
 	}
 
 	v := viper.New()
@@ -123,6 +127,9 @@ func New(path string) (*Config, error) {
 			return nil, err
 		}
 	}
+
+	// Allows to use $HOME in the cache path.
+	c.Data.Cache.Path = os.ExpandEnv(c.Data.Cache.Path)
 
 	return c, nil
 }

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -55,7 +55,7 @@ func StateDir() string {
 
 func ExpandPathWithoutTilde(path string) (string, error) {
 	if strings.HasPrefix(path, "~") {
-		return "", fmt.Errorf("%w: config path: %s", errTildeUsage, path)
+		return "", fmt.Errorf("%w: %s", errTildeUsage, path)
 	}
 
 	// Allows to use $HOME and other environment variables in the configuration

--- a/script/watch-test
+++ b/script/watch-test
@@ -3,6 +3,6 @@
 find . -not -path './.git/*' -not -path './dist/*' | \
     entr -c \
     bash -c '
-        go test -race -count 10 -race -count 10  -cover -coverprofile=coverage ./... &&
+        go test -race -count 10 -cover -coverprofile=coverage ./... &&
         go tool cover -html=coverage -o coverage.html
     '


### PR DESCRIPTION
This technically allows for any environment variable to be part of the config or cache path. So $HOME, $XDG_CONFIG_HOME, etc., can be used.

This was raised in #247 and will work nicely with the forbidding of `~`.

cc #246


E.g.

```shell
$ go run cmd/gh-not/main.go --config=~/.config/gh-not/config.yaml
...
failed to execute the root command: failed to load the config: failed to expand config path: tilde in path is not supported, use $HOME instead: ~/.config/gh-not/config.yaml
exit status 1

$ go run cmd/gh-not/main.go                                      
...
failed to execute the root command: failed to load the config: failed to expand cache path: tilde in path is not supported, use $HOME instead: ~/.local/state/gh-not/cache.json
exit status 1
```

