### PR TITLE
fix(repl): discard all output for `open` command

### DIFF
--- a/internal/repl/handlers.go
+++ b/internal/repl/handlers.go
@@ -1,8 +1,8 @@
 package repl
 
 import (
+	"io"
 	"log/slog"
-	"os"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
@@ -109,7 +109,7 @@ func (m model) handleBrowsing(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keymap.Open):
 		current, ok := m.list.SelectedItem().(item)
 		if ok {
-			err := m.actions["open"].Run(current.notification, nil, os.Stderr)
+			err := m.actions["open"].Run(current.notification, nil, io.Discard)
 			if err != nil {
 				slog.Warn("error opening", "notification", current.notification, "error", err)
 			}


### PR DESCRIPTION
This fixes the REPL printing a new line and breaking its display. 

The only useful output from this action is the confirmation that the notification was opened, so we can just ignore it when we open a single one.