### PR TITLE
fix(open): add separating space

### DIFF
--- a/internal/actions/open/open.go
+++ b/internal/actions/open/open.go
@@ -31,7 +31,7 @@ func (*Runner) Run(n *notifications.Notification, _ []string, w io.Writer) error
 		return errNoURL
 	}
 
-	fmt.Fprint(w, colors.Blue("OPEN ")+n.Subject.URL)
+	fmt.Fprint(w, colors.Blue("OPEN ")+n.Subject.URL+" ")
 
 	if err := b.Browse(n.Subject.HTMLURL); err != nil {
 		return fmt.Errorf("failed to open browser: %w", err)


### PR DESCRIPTION
This will enable using `GH_BROWSER=echo` without the api/html URL being jammed together.

Before:
```
OPEN https://api.github.com/repos/X/Y/pulls/Zhttps://github.com/X/Y/pull/Z
```

After:
```
OPEN https://api.github.com/repos/X/Y/pulls/Z https://github.com/X/Y/pull/Z
```