### PR TITLE
bugfix(repl): factor in the height of the statusBar into the list height

### DIFF
--- a/internal/repl/view.go
+++ b/internal/repl/view.go
@@ -57,7 +57,8 @@ func (m model) initView() model {
 func (m model) handleResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	slog.Debug("resize", "width", msg.Width, "height", msg.Height)
 
-	m.list.SetHeight(min(msg.Height, m.maxHeight))
+	// shorten the list height by one because statusLine is always 1 line
+	m.list.SetHeight(min(msg.Height, m.maxHeight) - 1)
 	m.list.SetWidth(msg.Width)
 
 	m.result.Height = min(msg.Height, m.maxHeight)


### PR DESCRIPTION
Because of the statusBar the list will always be 1 line shorter than the full window size.

Fixes: #272