### PR TITLE
chore(view.log_file): use XDG_STATE_DIR as default repl log location

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -256,7 +256,7 @@ func displayRepl(n notifications.Notifications) error {
 
 	// Launching bubbletea will occupy STDOUT and STDERR, so we need to redirect
 	// the logs to a file.
-	replLogFile := "/tmp/gh-not-debug.log"
+	replLogFile := config.Data.View.LogPath
 	slog.Debug("Repl view logs directed to separate file", "path", replLogFile)
 
 	f, err := logger.InitWithFile(verbosityFlag, replLogFile)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,8 @@ type Cache struct {
 type View struct {
 	// Number of notifications to display at once.
 	Height int `mapstructure:"height"`
+	// Where to write logs when repl is showing
+	LogPath string `mapstructure:"log_path"`
 }
 
 func Default(path string) (*viper.Viper, string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,7 @@ type Cache struct {
 type View struct {
 	// Number of notifications to display at once.
 	Height int `mapstructure:"height"`
-	// Where to write logs when repl is showing
+	// Where to write logs when REPL is showing.
 	LogPath string `mapstructure:"log_path"`
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -13,7 +13,7 @@ var Defaults = map[string]any{
 	"endpoint.per_page":  100,
 
 	"view.height":   40,
-	"view.log_path": path.Join(StateDir(), "gh-not-debug.log"),
+	"view.log_path": path.Join(StateDir(), "debug.log"),
 
 	"rules": []Rule{},
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -12,7 +12,8 @@ var Defaults = map[string]any{
 	"endpoint.max_page":  5,
 	"endpoint.per_page":  100,
 
-	"view.height": 40,
+	"view.height":   40,
+	"view.log_path": path.Join(StateDir(), "gh-not-debug.log"),
 
 	"rules": []Rule{},
 


### PR DESCRIPTION
The XDG specification proposes log files for user apps [go in the state directory](https://specifications.freedesktop.org/basedir-spec/latest/index.html#variables). I've made it configurable (but updated the default location).
This log file is currently only used for the REPL so I put it with the height config in the View Struct.