### PR TITLE
test: add rendering logs to debug display panic

### DIFF
--- a/internal/notifications/view.go
+++ b/internal/notifications/view.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -157,7 +158,11 @@ func (n Notifications) Render() error {
 		return fmt.Errorf("failed to render table: %w", err)
 	}
 
-	for i, l := range strings.Split(strings.TrimRight(out.String(), "\n"), "\n") {
+	tableLines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+
+	slog.Info("Rendered notifiation in a table", "notification count", len(n), "table line count", len(tableLines))
+
+	for i, l := range tableLines {
 		n[i].rendered = l
 	}
 

--- a/internal/notifications/view.go
+++ b/internal/notifications/view.go
@@ -143,7 +143,7 @@ func (n Notifications) Render() error {
 		printer.AddField(n.prettyState())
 		printer.AddField(n.Repository.FullName)
 		printer.AddField(n.Author.Login)
-		printer.AddField(n.Subject.Title)
+		printer.AddField(strings.ReplaceAll(n.Subject.Title, "\n", " "))
 
 		relativeTime := text.RelativeTimeAgo(time.Now(), n.UpdatedAt)
 		if n.LatestCommentor.Login != "" {


### PR DESCRIPTION
This add details during the rendering / caching process to debug why sometimes it would render more lines than notifications.

cc #288 