### PR TITLE
feat: make pass action log to show some output

### DIFF
--- a/internal/actions/pass/pass.go
+++ b/internal/actions/pass/pass.go
@@ -4,13 +4,16 @@ Package pass implements an [actions.Runner] that does nothing.
 package pass
 
 import (
+	"fmt"
 	"io"
 
+	"github.com/nobe4/gh-not/internal/colors"
 	"github.com/nobe4/gh-not/internal/notifications"
 )
 
 type Runner struct{}
 
-func (*Runner) Run(_ *notifications.Notification, _ []string, _ io.Writer) error {
+func (*Runner) Run(n *notifications.Notification, _ []string, w io.Writer) error {
+	fmt.Fprint(w, colors.Blue("PASS ")+n.String())
 	return nil
 }


### PR DESCRIPTION
I was using this action while testing my rule, where I just wanted to see what notifications got filtered.

Maybe this is more the intent of the `debug` action though.