### PR TITLE
Make notification enrichment atomic on failure

### DIFF
--- a/internal/gh/enrichments.go
+++ b/internal/gh/enrichments.go
@@ -30,6 +30,11 @@ func (c *Client) Enrich(n *notifications.Notification) error {
 		return err
 	}
 
+	lastCommentor, err := c.getLastCommentor(n)
+	if err != nil {
+		return err
+	}
+
 	n.Author = threadExtra.User
 	n.Subject.State = threadExtra.State
 	n.Subject.HTMLURL = threadExtra.HTMLURL
@@ -37,12 +42,6 @@ func (c *Client) Enrich(n *notifications.Notification) error {
 	n.Reviewers = threadExtra.Reviewers
 	n.ReviewersTeams = threadExtra.ReviewersTeams
 	n.MergedBy = threadExtra.MergedBy
-
-	lastCommentor, err := c.getLastCommentor(n)
-	if err != nil {
-		return err
-	}
-
 	n.LatestCommentor = lastCommentor
 
 	return nil

--- a/internal/gh/enrichments_test.go
+++ b/internal/gh/enrichments_test.go
@@ -25,13 +25,22 @@ func TestEnrichLeavesNotificationUnchangedOnFailure(t *testing.T) {
 		`"merged_by":{"login":"merger","type":"User"}` +
 		`}`
 
-	// seed builds a notification that already has some enriched fields, as it
-	// would after a prior (partially successful) Enrich pass.
+	oldUser := func(login string) notifications.User {
+		return notifications.User{Login: login, Type: "User"}
+	}
+
+	// seed builds a notification that already has enriched fields, as it could
+	// after a prior successful Enrich pass.
 	seed := func() *notifications.Notification {
 		n := mockNotification(0)
-		n.Author = notifications.User{Login: "old-author", Type: "User"}
+		n.Author = oldUser("old-author")
 		n.Subject.State = "closed"
-		n.LatestCommentor = notifications.User{Login: "old-commentor", Type: "User"}
+		n.Subject.HTMLURL = "https://example.com/old"
+		n.Assignees = []notifications.User{oldUser("old-assignee")}
+		n.Reviewers = []notifications.User{oldUser("old-reviewer")}
+		n.ReviewersTeams = []notifications.Team{{Name: "old-team", ID: 7}}
+		n.MergedBy = oldUser("old-merger")
+		n.LatestCommentor = oldUser("old-commentor")
 
 		return n
 	}

--- a/internal/gh/enrichments_test.go
+++ b/internal/gh/enrichments_test.go
@@ -1,0 +1,77 @@
+package gh
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/nobe4/gh-not/internal/api/mock"
+	"github.com/nobe4/gh-not/internal/notifications"
+)
+
+func TestEnrichLeavesNotificationUnchangedOnFailure(t *testing.T) {
+	t.Parallel()
+
+	threadExtraBody := `{` +
+		`"user":{"login":"new-author","type":"User"},` +
+		`"state":"open",` +
+		`"html_url":"https://example.com/issues/1",` +
+		`"assignees":[{"login":"assignee1","type":"User"}],` +
+		`"requested_reviewers":[{"login":"reviewer1","type":"User"}],` +
+		`"requested_teams":[{"name":"team1","id":42}],` +
+		`"merged_by":{"login":"merger","type":"User"}` +
+		`}`
+
+	// seed builds a notification that already has some enriched fields, as it
+	// would after a prior (partially successful) Enrich pass.
+	seed := func() *notifications.Notification {
+		n := mockNotification(0)
+		n.Author = notifications.User{Login: "old-author", Type: "User"}
+		n.Subject.State = "closed"
+		n.LatestCommentor = notifications.User{Login: "old-commentor", Type: "User"}
+
+		return n
+	}
+
+	tests := []struct {
+		name  string
+		calls []mock.Call
+	}{
+		{
+			name:  "thread extra fails",
+			calls: []mock.Call{{URL: mockSubjectURL(0), Error: errSample}},
+		},
+		{
+			name: "last commentor fails",
+			calls: []mock.Call{
+				{URL: mockSubjectURL(0), Response: &http.Response{Body: io.NopCloser(strings.NewReader(threadExtraBody))}},
+				{URL: mockLatestCommentURL(0), Error: errSample},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := seed()
+			n := seed()
+			client, m := mockClient(test.calls)
+
+			if err := client.Enrich(n); !errors.Is(err, errSample) {
+				t.Fatalf("expected %#v, got %#v", errSample, err)
+			}
+
+			if !reflect.DeepEqual(n, want) {
+				t.Errorf("notification mutated despite error\nwant: %#v\ngot:  %#v", want, n)
+			}
+
+			if err := m.Done(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/gh/enrichments_test.go
+++ b/internal/gh/enrichments_test.go
@@ -15,15 +15,15 @@ import (
 func TestEnrichLeavesNotificationUnchangedOnFailure(t *testing.T) {
 	t.Parallel()
 
-	threadExtraBody := `{` +
-		`"user":{"login":"new-author","type":"User"},` +
-		`"state":"open",` +
-		`"html_url":"https://example.com/issues/1",` +
-		`"assignees":[{"login":"assignee1","type":"User"}],` +
-		`"requested_reviewers":[{"login":"reviewer1","type":"User"}],` +
-		`"requested_teams":[{"name":"team1","id":42}],` +
-		`"merged_by":{"login":"merger","type":"User"}` +
-		`}`
+	threadExtraBody := `{
+		"user": { "login": "new-author", "type": "User" },
+		"state": "open",
+		"html_url": "https://example.com/issues/1",
+		"assignees": [{ "login": "assignee1", "type": "User" }],
+		"requested_reviewers": [{ "login": "reviewer1", "type": "User" }],
+		"requested_teams": [{ "name": "team1", "id": 42 }],
+		"merged_by": { "login": "merger", "type": "User" }
+	}`
 
 	oldUser := func(login string) notifications.User {
 		return notifications.User{Login: login, Type: "User"}


### PR DESCRIPTION
`Client.Enrich` used to update the notification after `getThreadExtra` succeeded, before calling `getLastCommentor`. If that second call failed, the function returned an error but left the notification partially enriched.

This changes `Enrich` to fetch all enrichment data first, then apply every notification update together after both calls succeed. The public signature and API call order are unchanged.

`TestEnrichLeavesNotificationUnchangedOnFailure` covers the atomicity invariant at both failure boundaries: when thread-extra fetching fails and when last-commentor fetching fails after thread-extra fetching succeeds.